### PR TITLE
Add package dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ setup(
     author='Michael duPont',
     author_email='michael@mdupont.com',
     license='MIT',
+    install_requires=[
+        'requests~=2.18.2',
+        'xmltodict~=0.11.0'
+    ],
     packages=[
         'avwx'
     ],


### PR DESCRIPTION
This will allow dependencies to be automatically verified or installed when running `pip install avwx-engine`.