### PR TITLE
Make datetimes timezone aware

### DIFF
--- a/avwx/__init__.py
+++ b/avwx/__init__.py
@@ -11,7 +11,7 @@ __stations__ = "2019-08-27"
 
 # stdlib
 from abc import abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 
 # module
 from avwx import (
@@ -97,7 +97,7 @@ class Report:
         self.raw = report
         if not disable_post:
             self._post_update()
-        self.last_updated = datetime.utcnow()
+        self.last_updated = datetime.utcnow().replace(tzinfo=timezone.utc)
         return True
 
     async def async_update(self, timeout: int = 10, disable_post: bool = False) -> bool:
@@ -230,7 +230,7 @@ class Reports:
         self.raw = self._report_filter(reports)
         if not disable_post:
             self._post_update()
-        self.last_updated = datetime.utcnow()
+        self.last_updated = datetime.utcnow().replace(tzinfo=timezone.utc)
         return True
 
     async def async_update(self, timeout: int = 10, disable_post: bool = False) -> bool:

--- a/avwx/_core.py
+++ b/avwx/_core.py
@@ -6,7 +6,7 @@ Contains the core parsing and indent functions of avwx
 import re
 from calendar import monthrange
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import permutations
 
 # library
@@ -1150,7 +1150,7 @@ def parse_date(
             return
         ihour = 2
     # Create initial guess
-    now = datetime.utcnow()
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
     day = now.day if time_only else int(date[0:2])
     # Handle situation where next month has less days than current month
     # Shifted value makes sure that a month shift doesn't happen twice


### PR DESCRIPTION
I am planning on using avwx-engine in a Django application that is already timezone aware and initializing the objects with the UTC timezone when they are already known UTC times will make the integration easier.