### PR TITLE
Fix AUBOM test

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -124,7 +124,7 @@ class TestMAC(TestService):
 class TestAUBOM(TestService):
 
     name = "AUBOM"
-    stations = ["YWOL", "YSSY"]
+    stations = ["YBBN", "YSSY"]
 
 
 class TestModule(unittest.TestCase):


### PR DESCRIPTION
YWOL doesn't seem to provide any TAF info any longer. Works with
Brisbane, YBBN.
