### PR TITLE
Initial work on refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,4 @@ target/
 /.pytest_cache/
 /.nox
 /notes.txt
-/site
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 /.nox
 /notes.txt
 /.idea
+/site
+.mypy_cache

--- a/avwx/_core.py
+++ b/avwx/_core.py
@@ -250,6 +250,7 @@ STR_REPL = {
     "KKT ": "KT ",
     "KLT ": "KT ",
     "CALMKT ": "CALM ",
+    "N0SIG": "NOSIG",
     " <1/": " M1/",  # <1/4SM <1/8SM
     " /34SM": "3/4SM",
 }

--- a/avwx/parsing/__init__.py
+++ b/avwx/parsing/__init__.py
@@ -1,0 +1,80 @@
+"""
+Package containing parsing feature
+"""
+from typing import Dict, List, Iterator, Set
+
+from .atom import BaseAtom, RegexAtom, AtomSpan
+from .atom_handlers import AtomHandler
+from .exceptions import CanNotHandleError, TranslationError
+
+
+class Parser:
+    def __init__(self):
+        self._handlers: List[AtomHandler] = []
+
+    @property
+    def handlers(self):
+        return list(self._handlers)
+
+    def register_handler(self, handler: AtomHandler) -> None:
+        """Register a handler"""
+        if not isinstance(handler, AtomHandler):
+            raise TypeError(f"handler must be of type {type(AtomHandler.__name__)}")
+        self._handlers.append(handler)
+
+    def unregister_handler(self, handler: AtomHandler) -> AtomHandler:
+        """Unregister a handler"""
+        try:
+            idx = self._handlers.index(handler)
+            return self._handlers.pop(idx)
+        except IndexError:
+            raise IndexError(f"{handler} not registered to parser")
+
+    def parse_into_translations(
+        self, string: str, strict: bool = True, prepend_error: str = "ERROR: "
+    ) -> Dict[str, str]:
+        """Parse a string into a dict of raw:translated string value pairs"""
+        if not isinstance(string, str):
+            raise TypeError("'string' must be a str")
+        if not string:
+            return {}
+
+        out: Dict[str, str] = {}
+
+        working_string = string[::]
+        valid_handlers = self._iter_handlers_that_can_handle_string(working_string)
+        current_handler = next(valid_handlers)
+
+        failed_handlers: Set[AtomHandler] = set()
+
+        while current_handler is not None:
+            try:
+                if current_handler in failed_handlers:
+                    current_handler = next(valid_handlers)
+                    continue
+
+                translation = current_handler.translate(working_string)
+                raw, working_string = current_handler.atom.extract_atom_from_string(
+                    working_string
+                )
+
+                out[raw] = translation
+                current_handler = next(valid_handlers)
+
+            except TranslationError as e:
+                if strict is False:
+                    error_str = str(e)
+                    translation = prepend_error + error_str
+                    out[current_handler.atom.name] = translation
+                    failed_handlers.add(current_handler)
+                else:
+                    raise e
+            except StopIteration:
+                break
+
+        return out
+
+    def _iter_handlers_that_can_handle_string(
+        self, string: str
+    ) -> Iterator[AtomHandler]:
+        return (handler for handler in self.handlers if handler.can_handle(string))

--- a/avwx/parsing/atom.py
+++ b/avwx/parsing/atom.py
@@ -1,0 +1,119 @@
+import abc
+import re
+from typing import Optional, NamedTuple, Tuple, Dict
+
+
+class AtomSpan(NamedTuple):
+    """
+    Finding within a string. Can be used for slicing as `end` is non-inclusive.
+
+    'context' is a Dict[str,str] that can be used in translation functions.
+    """
+
+    match: Optional[str]
+    start: Optional[int]
+    end: Optional[int]
+    context: Optional[Dict[str, str]]
+
+
+# todo: add make_context
+class BaseAtom(abc.ABC):
+    """Atom represents a single encoded entity in an encoded string"""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @abc.abstractmethod
+    def to_atom_span(self, item: str) -> AtomSpan:
+        """Return an `AtomSpan`. If no match found, return `AtomSpan(None, None, None)`"""
+        pass
+
+    def find_atom_in_string(self, string: str) -> Optional[str]:
+        """Return the matching atom from a string"""
+        return self.to_atom_span(string).match
+
+    def is_in(self, string: str) -> bool:
+        """Return True if the atom is in the string"""
+        return self.find_atom_in_string(string) is not None
+
+    # todo: add strip
+    def extract_atom_from_string(self, string: str) -> Tuple[str, str]:
+        """
+        Return extracted atom and string with atom extracted
+
+        For instance, if the atom were "some string" and the input were
+        "this is some string I have"..
+
+        return -> "some string", "this is  I have"
+        """
+        span = self.to_atom_span(string)
+        if span.start is None or span.end is None:
+            raise ValueError(f"Atom: '{self.name}' not in '{string}'")
+        else:
+            match = span.match or ""
+            extract = string[: span.start] + string[span.end :]
+
+            return match, extract
+
+
+# todo: enforce name
+class RegexAtom(BaseAtom):
+    """Atom defined by regex pattern"""
+
+    def __init__(self, regex_pattern: re.Pattern, name: str):
+        self.regex = regex_pattern
+        super().__init__(name)
+
+    def __repr__(self):
+        return f"{type(self).__name__}(pattern={self.regex!r}, name={self.name})"
+
+    @property
+    def regex(self) -> re.Pattern:
+        return self._regex
+
+    @regex.setter
+    def regex(self, regex: re.Pattern):
+        if not isinstance(regex, re.Pattern):
+            raise TypeError("regex must be a compiled `re.Pattern`")
+        self._regex = regex
+
+    # fixme: name should NOT be optional
+    @classmethod
+    def from_pattern_string(
+        cls, pattern: str, *flags: re.RegexFlag, name: Optional[str] = None
+    ) -> "RegexAtom":
+        """
+        Return a new instance of `RegexAtom` from a string pattern.
+
+        :param pattern: string to be compiled into regex pattern
+        :param flags: flags to pass to `re.compile`
+        :param name: name for repr
+        """
+
+        if flags:
+            regex = re.compile(pattern, sum(flags))
+        else:
+            regex = re.compile(pattern)
+
+        out = cls(regex, name=name)
+
+        return out
+
+    def to_atom_span(self, string: str) -> AtomSpan:
+        """
+        Search the string for the atom
+        """
+        match = self.regex.search(string)
+        if match:
+            start, stop = match.span()
+            return AtomSpan(
+                match=match.group(), start=start, end=stop, context=match.groupdict()
+            )
+        return AtomSpan(match=None, start=None, end=None, context={})
+
+    # todo: remove to use context in `to_atom_span` instead
+    def search(self, string: str) -> Optional[re.Match]:
+        """
+        Return `re.Match` object or None
+        """
+        return self.regex.search(string)

--- a/avwx/parsing/atom.py
+++ b/avwx/parsing/atom.py
@@ -3,6 +3,7 @@ import re
 from typing import Optional, NamedTuple, Tuple, Dict
 
 
+# todo: add text
 class AtomSpan(NamedTuple):
     """
     Finding within a string. Can be used for slicing as `end` is non-inclusive.
@@ -23,6 +24,7 @@ class BaseAtom(abc.ABC):
     def __init__(self, name: str):
         self.name = name
 
+    # todo: decorate to return an empty atom string from a False return value
     @abc.abstractmethod
     def to_atom_span(self, item: str) -> AtomSpan:
         """Return an `AtomSpan`. If no match found, return `AtomSpan(None, None, None)`"""
@@ -84,6 +86,15 @@ class RegexAtom(BaseAtom):
     ) -> "RegexAtom":
         """
         Return a new instance of `RegexAtom` from a string pattern.
+
+        .. note::
+
+            It is important to ensure that patterns are raw strings, just like
+            you were creating a compiled regex pattern normally.
+
+        .. code-block::
+
+            aircraft_mishap_atom = RegexAtom.from_pattern_string(r"\bACFT MSHP\b")
 
         :param pattern: string to be compiled into regex pattern
         :param flags: flags to pass to `re.compile`

--- a/avwx/parsing/atom_handlers.py
+++ b/avwx/parsing/atom_handlers.py
@@ -1,0 +1,104 @@
+"""
+AtomHandler:
+    * bundles atom and some translation callable together to be executed with arbitrary strings
+
+TranslationCallable:
+    * A client defined callable that operates on an AtomSpan and an input string
+
+    example:
+
+
+        def sea_level_pressure_translation(span, input_: str) -> str:
+            match = span.match
+            if not match:
+                raise TranslationError("some descriptive error")
+            else:
+                pressure = match[3:].strip()
+
+            return f"Sea Level Pressure {pressure}"
+
+        -- or with a RegEx Atom --
+
+        def sea_level_pressure_translation(span, input_: str) -> str:
+            context = span.context
+            if not match:
+                raise TranslationError("some descriptive error")
+
+            return f"Sea Level Pressure {data["pressure"]}"
+
+    * TranslationError - should be raised when there is a problem during the translation.
+        - This should be used instead of a ValueError so that the handler can decide what to do instead. Maybe
+        a default translation or error code should be used instead for cleanup
+"""
+
+from typing import NamedTuple
+
+from .exceptions import CanNotHandleError, TranslationError
+from .atom import AtomSpan, BaseAtom
+from .translation import Translation
+
+
+class TranslationResult(NamedTuple):
+    pass
+
+
+# todo: multiple translations for a single atom?
+# todo: add name enforcement
+class AtomHandler:
+    """Handle the individual translation of an atom"""
+
+    def __init__(
+        self, atom: BaseAtom, translation_callable: Translation, name: str = None
+    ):
+        self.atom = atom
+        self.translation_callable = translation_callable
+        self.name = name
+
+    def __repr__(self):
+        return f"{type(self).__name__}(atom: {self.atom.name})"
+
+    def __call__(self, string: str, *args, **kwargs):
+        return self.translate(string)
+
+    @property
+    def translation_callable(self):
+        return self._translation_callable
+
+    @translation_callable.setter
+    def translation_callable(self, new_callable: Translation):
+        if not callable(new_callable):
+            raise TypeError(
+                "translation_callable must be a callable that accepts a `BaseAtom` and a string"
+            )
+        self._translation_callable = new_callable
+
+    @classmethod
+    def create_simple_translation(
+        cls, atom: BaseAtom, output: str, name: str
+    ) -> "AtomHandler":
+        """Return a new `AtomHandler` which will return a simple string as a translation"""
+
+        def translation(span: AtomSpan, string: str):
+            return output
+
+        out = cls(atom, translation, name)
+
+        return out
+
+    def can_handle(self, atom_string: str) -> bool:
+        """Return True if handler is qualified to handle translation"""
+        return self.atom.is_in(atom_string)
+
+    # todo: allow for default error handling option
+    def translate(self, string: str) -> str:
+        """Perform translation on the atom string"""
+        span = self.atom.to_atom_span(string)
+        if not self.atom.is_in(string):
+            raise CanNotHandleError(
+                f"{self.atom!r} has nothing to translate from {string!r}"
+            )
+
+        # todo: defer to private wrapper that handles error?
+        result = self.translation_callable(span, string)
+
+        return result

--- a/avwx/parsing/exceptions.py
+++ b/avwx/parsing/exceptions.py
@@ -1,0 +1,21 @@
+"""
+Exceptions for 'parsing' package
+"""
+
+
+class AtomHandlerException(Exception):
+    """Base Exception for `AtomHandler` operations"""
+
+    pass
+
+
+class CanNotHandleError(AtomHandlerException):
+    """Can not execute translation due to bad match"""
+
+    pass
+
+
+class TranslationError(AtomHandlerException):
+    """Unexpected error occurred during translation"""
+
+    pass

--- a/avwx/parsing/translation.py
+++ b/avwx/parsing/translation.py
@@ -1,0 +1,29 @@
+"""
+Module containing potential Translation class.
+
+For now a Translation can be any callable that returns a translated string using the information gleaned from
+and `AtomSpan`. This keeps a separation between the logic that defines WHAT is an atom from how it is translated.
+This could potentially extend to different translations for different weather provider translations and possibly
+even a plugin in system for different language implementations and translation selection at runtime.
+
+An example of a translation might be one that uses the context provided by an AtomSpan in the following way..
+
+Given an Atom that matches the pattern `\bPRES(?P<trend>R|F)R\b`..
+
+
+def pressure_change(span: AtomSpan, string: str) -> str:
+    trend = {"R": "rising", "F": "falling"}.get(span.context["trend"])
+
+    return f"Pressure {trend} rapidly"
+
+
+The TranslationError should be raised for any specific conditions that aren't met. This will propagate to the
+handler that called the translation so it can decide if there is a fallback translation, make an error string,
+or to simply pluck the match that couldn't be translated from the input string so it doesn't try to get matched again.
+"""
+
+from typing import Callable
+from .atom import AtomSpan
+
+
+Translation = Callable[[AtomSpan, str], str]

--- a/avwx/patterns/__init__.py
+++ b/avwx/patterns/__init__.py
@@ -1,0 +1,1 @@
+from . import remarks

--- a/avwx/patterns/remarks.py
+++ b/avwx/patterns/remarks.py
@@ -1,0 +1,144 @@
+import re
+
+
+# Reusable snippets
+
+VISIBILTY_PATTERN = r"[\d/\s]{1,5}"
+RUNWAY_PATTERN = r"RWY\d{2}[LCR]?"
+SURFACE_LOCATION_PATTERN = rf"(?:TWR|{RUNWAY_PATTERN})"
+DIRECTION_PATTERN = r"[NSEW]{1,3}"
+
+# Compiled patterns
+
+AIRCRAFT_MISHAP_RE = re.compile(r"\bACFT MSHP\b")
+
+AUTOMATED_STATION_RE = re.compile(r"\bAO[12]\b")
+
+"""
+BEGINNING AND ENDING OF PRECIPITATION AND THUNDERSTORM
+w'w'B(hh)mmE(hh)mm; TSB(hh)mmE(hh)mm
+"""
+BEGINNING_ENDING_OF_PRECIP_AND_TS = re.compile(
+    r"""
+\b
+(?P<precip>RA|TS)
+(?P<first>
+  (?P<first_type>[BE])
+  (?P<first_time>\d{4}|\d{2})
+)
+(?P<second>
+  (?#
+    Do not match unless time ends word
+  )
+  (?:(?=[BE]\d{1,4}\b)
+  (?P<second_type>[BE])
+  (?P<second_time>\d{4}|\d{2})?
+)
+)?
+""",
+    re.VERBOSE,
+)
+
+CEILING_HEIGHT_AT_SECOND_LOCATION_RE = re.compile(
+    r"""
+    \bCIG
+    \s
+    (?P<height>\d{3})
+    \s
+    (?P<location>RWY\d{2}[LCR]?)\b
+    """,
+    re.VERBOSE,
+)
+
+LIGHTNING_RE = re.compile(
+    rf"""
+\b(?P<frequent>FRQ)?
+\s?
+\bLTG
+(?:\s(?P<direction>{DIRECTION_PATTERN}))?
+""",
+    re.VERBOSE,
+)
+
+PEAK_WIND_RE = re.compile(
+    r"""
+    \bPK[_\s]WND[_\s]
+    (?P<direction>\d{3})
+    (?P<speed>\d{2,3})
+    /
+    (?P<hours>\d{2})?
+    (?P<minutes>\d{2})
+    \b
+    """,
+    re.VERBOSE,
+)
+
+PRESSURE_CHANGE_RE = re.compile(r"\bPRES(?P<direction>[FR])R\b")
+
+REMARKS_IDENTIFIER_RE = re.compile(r"\bRMK\b")
+
+SEA_LEVEL_PRESSURE_RE = re.compile(r"\bSLP(?P<pressure>\d{1,3})\b")
+
+TORNADO_ACTIVITY_RE = re.compile(
+    r"""
+\b(?P<activity>TORNADO|FUNNEL\sCLOUD|WATERSPOUT)\b
+\s?
+(?P<began_ended>[BE])?
+(?P<minutes>\d\d)?
+\s?
+(?P<location>[NSEW]{1,3})?
+(?:\sMOV\s)?
+(?P<movement>[NSEW]{1,3})?
+""",
+    re.VERBOSE,
+)
+
+TOWER_OR_SURFACE_VISIBILITY_RE = re.compile(
+    fr"""
+    \b(?P<location>TWR|SFC)
+    \sVIS\s
+    (?P<visibility>{VISIBILTY_PATTERN})
+    \b
+    """,
+    re.VERBOSE,
+)
+
+VARIABLE_CEILING_HEIGHT_RE = re.compile(
+    r"\bCIG\s(?P<lower>\d{1,3})V(?P<upper>\d{1,3})\b"
+)
+
+VARIABLE_PREVAILING_VISIBILITY_RE = re.compile(
+    fr"""
+    \bVIS\s
+    (?P<lower>{VISIBILTY_PATTERN})
+    V
+    (?P<upper>{VISIBILTY_PATTERN})
+    \b
+    """,
+    re.VERBOSE,
+)
+
+VIRGA_RE = re.compile(r"\bVIRGA\b")
+
+"""
+VISIBILITY AT SECOND LOCATION: VIS vvvvv [LOC] 
+reported if different than the reported prevailing visibility in body of report.
+ex: VIS 3/4 RWY11
+"""
+VISIBILITY_AT_SECOND_LOCATION_RE = re.compile(
+    rf"""
+\bVIS\s
+(?P<visibility>{VISIBILTY_PATTERN})
+\s
+(?P<location>{SURFACE_LOCATION_PATTERN})\b
+""",
+    re.VERBOSE,
+)
+
+WIND_SHIFT_RE = re.compile(r"\bWSHFT\s(?P<hours>\d{2})?(?P<minutes>\d{2})")
+
+# clean up namespace
+del VISIBILTY_PATTERN
+del RUNWAY_PATTERN
+del SURFACE_LOCATION_PATTERN
+del DIRECTION_PATTERN

--- a/avwx/patterns/remarks.py
+++ b/avwx/patterns/remarks.py
@@ -18,6 +18,7 @@ AUTOMATED_STATION_RE = re.compile(r"\bAO[12]\b")
 BEGINNING AND ENDING OF PRECIPITATION AND THUNDERSTORM
 w'w'B(hh)mmE(hh)mm; TSB(hh)mmE(hh)mm
 """
+# todo: Add other precip types
 BEGINNING_ENDING_OF_PRECIP_AND_TS = re.compile(
     r"""
 \b

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,4 +30,5 @@ These docs could use some love, and I am not a writer. You can help by making a 
 * [Service](service.md)
 * [Static Values](static.md)
 * [Data Structures](structs.md)
+* [Parsing](parsing.md)
 * [Exceptions](exceptions.md)

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -1,0 +1,197 @@
+# Parsing and Translating
+
+A body of a weather report is generally composed of a series of encoded chunks
+that can be interpreted as static or dynamic/encoded and/or single or multi-worded 
+elements. These elements follow specific patterns defined in technical documents that
+provide for relatively easy decoding (provided they don't change). We'll call these
+elements of data "Atoms". 
+
+## The Atom Objects
+
+Atoms define an element's pattern in a corpus of text. They are generally created using
+regular expressions, but can be extended to define themselves by other means by subclassing
+the `BaseAtom`, provided they implement the `to_atom_span(string: str) -> AtomSpan` method. 
+The easiest way to create a `RegexAtom` is using the `RegexAtom.from_pattern_string` class
+method. 
+
+```python
+from avwx.parsing import RegexAtom
+
+aircraft_mishap_atom = RegexAtom.from_pattern_string(r"\bACFT MSHP\b", "Aircraft Mishap")
+```
+
+If you're making a more complicated pattern with some encoded data, you can add flags.
+
+```python
+# patterns/remarks.py
+
+BEGINNING_ENDING_OF_PRECIP_AND_TS = r"""
+\b
+(?P<precip>RA|TS)
+(?P<first>
+  (?P<first_type>[BE])
+  (?P<first_time>\d{4}|\d{2})
+)
+(?P<second>
+  (?#
+    Do not match unless time ends word
+  )
+  (?:(?=[BE]\d{1,4}\b)
+  (?P<second_type>[BE])
+  (?P<second_time>\d{4}|\d{2})?
+)
+)?
+"""
+
+# remarks.py
+
+begin_end_precip_ts_atom = RegexAtom.from_pattern_string(
+    BEGINNING_ENDING_OF_PRECIP_AND_TS, re.VERBOSE, name="Begin End Precip Ts"
+)
+```
+
+Now this Atom can be easily identified in a bigger string using the `BaseAtom` 
+interface. 
+
+```python
+s = "The pattern for precip times look like this RAB24E53"
+
+print(begin_end_precip_ts_atom.is_in(s)) # True
+```
+
+Keeping the element finding logic separate from the handling logic offers a few
+beneifts, with the tradeoff of a little more complexity. Since these elements may
+have some undocumented patterns that should be easily added later. Let's add the
+ability to match snow as a precip type.
+
+```python
+# patterns/remarks.py
+BEGINNING_ENDING_OF_PRECIP_AND_TS = r"""
+\b
+(?P<precip>RA|TS|SN)
+(?P<first>
+  (?P<first_type>[BE])
+  (?P<first_time>\d{4}|\d{2})
+)
+(?P<second>
+  (?#
+    Do not match unless time ends word
+  )
+  (?:(?=[BE]\d{1,4}\b)
+  (?P<second_type>[BE])
+  (?P<second_time>\d{4}|\d{2})?
+)
+)?
+"""
+```
+
+That's it. Now the atom can be used to identify snow as precip type. More about
+how these values are used in the translation callables section. 
+
+### `avwx.parsing.BaseAtom`
+
+##### Attributes
+
+* `name: str` - the name of the atom, for debugging purposes
+
+#### Abstract Methods
+* `to_atom_string(string: str) -> bool` - return an `AtomString` from the string. If no match
+should be made from the string, return an `AtomString` with empty values.
+
+#### Methods
+
+* `is_in(string: str) -> bool` -  return `True` if the atom is contained within the string
+
+* `extract_atom_from_string(string: str) -> Tuple[str, str]` - return a tuple containing the 
+match and the string with the match extracted. Raise a `ValueError` if the atom is not in the 
+provided string. 
+
+* `find_atom_in_string(string: str) -> Optional[str]` -  return the matching text from a string
+or None
+
+### `avwx.parsing.RegexAtom`
+Subclass of `BaseAtom` that uses Python's builtin regular expressions internally. 
+
+#### Attributes
+
+* `regex` - a compiled `re.Pattern` object
+
+
+
+## The Atom Span Object
+
+`AtomSpan` objects are the main product of the atom classes. They define *where* an atom
+is located in a larger body of text. In fact, **all subclasses of BaseAtom must implement
+the `to_atom_span(string: str) -> AtomSpan` method**. This is the main driver
+for the convenience methods of the `BaseAtom` class.
+
+
+### `avwx.parsing.AtomSpan`
+A named tuple representing the presence of an atom within the body of a larger string
+along with any decoded information. 
+
+#### Attributes:
+
+* `match` - string: the raw matching text from a larger string
+
+* `start` - int: the location of the first character of the atom within a larger string
+
+* `end` - int: the first character that does not include the atom, matches string slicing 
+behavior
+
+* `context` - `Dict[str, str]`: dict containing decoded information from the atom by keyword
+
+#### [ ] todo: add text field info
+
+## The Translation Callables
+
+For now, translation callables are any callable that accepts an `AtomSpan` and an input string and returns a translated string. This means that a class
+could be defined for a more extentable translation that implements the `__call__(self, atom: AtomSpan, string: str) -> str` method. 
+
+```python
+
+# avwx/remarks.py
+
+def begin_end_of_precip_trans(span: AtomStpan, string: str) -> str:
+  """Rain|Thunderstorm|Snow began|ended at [HH]MM [and ended at [HH]MM]"""
+  match = atom.to_atom_span(string).match
+
+  if match:
+      data = atom.to_data_dict(match)
+  else:
+      raise TranslationError(f"no match could be made from {string}")
+
+  precip_options = {"RA": "Rain", "TS": "Thunderstorm": "SN": "Snow"}
+
+  time_options = {"B": "began", "E": "ended"}
+
+  precip = precip_options.get(data["precip"])
+  first_time_type = time_options.get(data["first_type"])
+  first_time = data.get("first_time")
+
+  first_string = f"{first_time_type} at {first_time}"
+
+  out = f"{precip} {first_string}"
+
+  if data.get("second"):
+      second_time_type = time_options.get(data["second_type"])
+      second_time = data.get("second_time")
+
+      second_string = f"and {second_time_type} at {second_time}"
+
+      out = f"{out} {second_string}"
+
+  return out
+```
+
+If it is determined that a translation can not be made from the input, `TranslationError` should be raised explaining why. 
+
+## The Handler Object
+
+## Putting It All Together Into a Parser Object
+
+## How Are Errors Handled?
+
+## Can Parsers Be Configured at Runtime?
+
+## Adding Multiple Translations to a Single Handler

--- a/tests/patterns/test_remarks_patterns.py
+++ b/tests/patterns/test_remarks_patterns.py
@@ -1,0 +1,184 @@
+"""Tests for the remarks module in the patterns package"""
+
+import pytest
+
+import avwx.patterns.remarks as rp
+from tests.patterns.utils import assert_match, assert_group_dict
+
+param = pytest.mark.parametrize  # alias
+
+
+@param("inp, should_match", [(" ACFT MSHP ", True), (" ANACFT_MSHP ", False)])
+def test_aircraft_mishap(inp, should_match):
+    """Aircraft Mishap"""
+    assert_match(rp.AIRCRAFT_MISHAP_RE, inp, should_match)
+
+
+@param(
+    "inp, should_match",
+    [(" AO1 ", True), (" AO2 ", True), (" AO3 ", False), (" AAO1 ", False),],
+)
+def test_automated_station(inp, should_match):
+    """Automated Station"""
+    assert_match(rp.AUTOMATED_STATION_RE, inp, should_match)
+
+
+@param(
+    "inp, direction, speed, hours, minutes",
+    [
+        (" PK WND 36050/0130 ", "360", "50", "01", "30"),
+        (" PK_WND_36050/0130 ", "360", "50", "01", "30"),
+        (" PK_WND_36050/30 ", "360", "50", None, "30"),
+    ],
+)
+def test_peak_wind_groups(inp, direction, speed, hours, minutes):
+    """Peak Wind"""
+    exp_dict = {
+        "direction": direction,
+        "speed": speed,
+        "hours": hours,
+        "minutes": minutes,
+    }
+    assert_group_dict(rp.PEAK_WIND_RE, inp, exp_dict)
+
+
+@param(
+    "inp, hours, minutes", [(" WSHFT 0123 ", "01", "23"), (" WSHFT 23 ", None, "23"),]
+)
+def test_wind_shift(inp, hours, minutes):
+    """Wind Shift"""
+    exp_dict = {"hours": hours, "minutes": minutes}
+    assert_group_dict(rp.WIND_SHIFT_RE, inp, exp_dict)
+
+
+@param("inp, lower, upper", [(" CIG 012V345 ", "012", "345"), (" CIG 1V2 ", "1", "2")])
+def test_variable_ceiling_height(inp, lower, upper):
+    """Variable Ceiling Height"""
+    exp_dict = {"lower": lower, "upper": upper}
+    assert_group_dict(rp.VARIABLE_CEILING_HEIGHT_RE, inp, exp_dict)
+
+
+@param("inp, direction", [(" PRESFR ", "F"), (" PRESRR ", "R")])
+def test_pressure_change(inp, direction):
+    """Pressure Change"""
+    exp_dict = {"direction": direction}
+
+    assert_group_dict(rp.PRESSURE_CHANGE_RE, inp, exp_dict)
+
+
+@param(
+    "inp, location, visibility",
+    [
+        (" TWR VIS 1 ", "TWR", "1"),
+        (" TWR VIS 1/2 ", "TWR", "1/2"),
+        (" SFC VIS 1/4 ", "SFC", "1/4"),
+    ],
+)
+def test_tower_or_surface_visibility(inp, location, visibility):
+    """Tower or Surface Visibility"""
+    match = rp.TOWER_OR_SURFACE_VISIBILITY_RE.search(inp)
+
+    assert match.groupdict() == {"location": location, "visibility": visibility}
+
+
+@param(
+    "inp, vis, loc",
+    [("VIS 3/4 RWY11", "3/4", "RWY11"), ("VIS 1 1/2 RWY01", "1 1/2", "RWY01")],
+)
+def test_secondary_location_visibility(inp, vis, loc):
+    """Visibility at Second Location"""
+    expected_dict = {"visibility": vis, "location": loc}
+
+    assert_group_dict(rp.VISIBILITY_AT_SECOND_LOCATION_RE, inp, expected_dict)
+
+
+@param(
+    "inp, lower, upper",
+    [(" VIS 3/4V1 1/2 ", "3/4", "1 1/2"), (" VIS 1 1/2V2 3/4 ", "1 1/2", "2 3/4")],
+)
+def test_variable_prevailing_visibility(inp, lower, upper):
+    """Variable Prevailing Visibility"""
+    match = rp.VARIABLE_PREVAILING_VISIBILITY_RE.search(inp)
+
+    assert match.groupdict() == {"lower": lower, "upper": upper}
+
+
+@param("inp, pressure", [("SLP123", "123"), ("SLP12", "12"),])
+def test_sea_level_pressure(inp, pressure):
+    """Sea Level Pressure"""
+    match = rp.SEA_LEVEL_PRESSURE_RE.search(inp)
+
+    assert match.groupdict() == {"pressure": pressure}
+
+
+@param(
+    "inp, activity, began_ended, minutes, loc, move",
+    [
+        ("TORNADO", "TORNADO", None, None, None, None),
+        ("WATERSPOUT B25 NNE MOV W", "WATERSPOUT", "B", "25", "NNE", "W"),
+    ],
+)
+def test_tornado_activity(inp, activity, began_ended, minutes, loc, move):
+    """Tornado Activity"""
+
+    assert_group_dict(
+        rp.TORNADO_ACTIVITY_RE,
+        inp,
+        {
+            "activity": activity,
+            "began_ended": began_ended,
+            "minutes": minutes,
+            "location": loc,
+            "movement": move,
+        },
+    )
+
+
+@param(
+    "inp, freq, loc",
+    [("FRQ LTG NE", "FRQ", "NE"), ("LTG", None, None), ("LTG SSW", None, "SSW")],
+)
+def test_lightning(inp, freq, loc):
+    """Lightning"""
+    expected = {"frequent": freq, "direction": loc}
+
+    assert_group_dict(rp.LIGHTNING_RE, inp, expected)
+
+
+_input_params = (
+    "inp, precip, first, first_type, first_time, second, second_type, second_time"
+)
+
+
+@param(
+    _input_params,
+    [
+        ("RAB0123E1234", "RA", "B0123", "B", "0123", "E1234", "E", "1234"),
+        ("RAB12", "RA", "B12", "B", "12", None, None, None),
+        ("  TSE1234  ", "TS", "E1234", "E", "1234", None, None, None),
+        ("TSB12E0112", "TS", "B12", "B", "12", "E0112", "E", "0112"),
+    ],
+)
+def test_beginning_ending_of_precip_and_ts(
+    inp, precip, first, first_type, first_time, second, second_type, second_time,
+):
+    """Beginning and Ending of Precipitation/Thunderstorm"""
+    expected = {
+        "precip": precip,
+        "first": first,
+        "first_type": first_type,
+        "first_time": first_time,
+        "second": second,
+        "second_type": second_type,
+        "second_time": second_time,
+    }
+
+    assert_group_dict(rp.BEGINNING_ENDING_OF_PRECIP_AND_TS, inp, expected)
+
+
+@param("inp, height, location", [("CIG 017 RWY11", "017", "RWY11")])
+def test_ceiling_at_second_location(inp, height, location):
+    """Ceiling at Second Location"""
+    expected = {"height": height, "location": location}
+
+    assert_group_dict(rp.CEILING_HEIGHT_AT_SECOND_LOCATION_RE, inp, expected)

--- a/tests/patterns/utils.py
+++ b/tests/patterns/utils.py
@@ -1,0 +1,28 @@
+import re
+from pprint import pformat
+
+
+def assert_match(pattern: re.Pattern, inp: str, should_match: bool):
+    """
+    Assert the pattern results in a match when searched with inp.
+    `should_match` can be True to negate the assertion.
+    """
+    match = pattern.search(inp)
+    if should_match:
+        assert match, match
+    else:
+        assert match is None, match
+
+
+def assert_group_dict(pattern: re.Pattern, inp: str, expected_dict: dict):
+    """Assert the pattern matches group dict from input"""
+    match = pattern.search(inp)
+
+    assert match is not None, f"No match upon search... result:\n{match}"
+
+    gp_dct = match.groupdict()
+
+    error_message = f"EXPECTED: \n{pformat(expected_dict)}\nGOT: \n{pformat(gp_dct)}"
+
+    for exp_k, exp_v in expected_dict.items():
+        assert gp_dct.get(exp_k) == exp_v, error_message

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -1,0 +1,134 @@
+import pytest
+import re
+from unittest import mock
+
+from avwx.parsing.atom import AtomSpan, RegexAtom, BaseAtom
+
+
+@pytest.fixture
+def pattern_string():
+    return r"\bSOME PATTERN P(?P<digits>\d{1,5})\b"
+
+
+@pytest.fixture
+def pattern(pattern_string):
+    return re.compile(pattern_string)
+
+
+@pytest.fixture
+def regex_atom(pattern):
+    return RegexAtom(pattern, name="Some Pattern")
+
+
+SUCCESS_STRING = "HERE IS SOME PATTERN P123 THING"
+FAIL_STRING = "YOU HAVE NO MATCH HERE"
+
+
+@pytest.fixture
+def base_atom_subclass():
+    class SubAtom(BaseAtom):
+        def to_atom_span(self, item: str) -> AtomSpan:
+            raise NotImplementedError("tests should mock this")
+
+    return SubAtom
+
+
+@pytest.fixture
+def mocked_atom_subclass(base_atom_subclass):
+    mock_to_atom_span = mock.MagicMock()
+    base_atom_subclass.to_atom_span = mock_to_atom_span
+
+    return base_atom_subclass
+
+
+@pytest.fixture
+def mocked_atom_instance(mocked_atom_subclass):
+    atom = mocked_atom_subclass("sample atom")
+    return atom
+
+
+class TestBaseAtom:
+    def test_constructor(self, base_atom_subclass):
+        sub = base_atom_subclass("base atom")
+        assert sub.name == "base atom"
+
+    def test_is_in(self, mocked_atom_instance):
+        atom = mocked_atom_instance
+        atom.to_atom_span.return_value.match = "something"
+
+        assert atom.is_in("string")
+
+    def test_is_in_returns_false(self, mocked_atom_instance):
+        atom = mocked_atom_instance
+        atom.to_atom_span.return_value.match = None
+
+        assert not atom.is_in("string")
+
+    def test_find_atom_in_string(self, mocked_atom_instance):
+        atom = mocked_atom_instance
+        atom.to_atom_span.return_value.match = "string"
+
+        assert atom.find_atom_in_string("this is a string") == "string"
+
+    def test_find_atom_in_string_return_none(self, mocked_atom_instance):
+        atom = mocked_atom_instance
+        atom.to_atom_span.return_value.match = None
+
+        assert atom.find_atom_in_string("this is a string") is None
+
+    def test_extract_atom_from_string(self, mocked_atom_instance):
+        s = "012345string23456789"
+
+        atom = mocked_atom_instance
+        atom.to_atom_span.return_value = AtomSpan(
+            match="string", start=6, end=12, context={},
+        )
+
+        assert ("string", "01234523456789") == atom.extract_atom_from_string(s)
+
+    def test_extract_atom_from_string_raises(self, mocked_atom_subclass):
+        atom = mocked_atom_subclass(name="some atom")
+        atom.to_atom_span.return_value = AtomSpan(None, None, None, None)
+
+        with pytest.raises(ValueError) as exc_info:
+            atom.extract_atom_from_string("some string")
+
+        assert "Atom: 'some atom' not in 'some string'" in str(exc_info.value)
+
+
+class TestRegexAtom:
+    def test_constructor(self, regex_atom, pattern):
+        atom = regex_atom
+        assert atom is not None
+        assert atom.regex == pattern
+        assert isinstance(atom._regex, re.Pattern)
+        assert atom.name == "Some Pattern"
+
+    def test_to_atom_span(self, regex_atom):
+        exp = AtomSpan(
+            match="SOME PATTERN P123", start=8, end=25, context={"digits": "123"}
+        )
+        match, start, end, context = regex_atom.to_atom_span(SUCCESS_STRING)
+
+        assert regex_atom.to_atom_span(SUCCESS_STRING) == exp
+        assert SUCCESS_STRING[start:end] == match
+
+    def test_is_in(self, regex_atom):
+        assert regex_atom.is_in(SUCCESS_STRING)
+
+    def test_from_pattern_string(self, pattern_string):
+        atom = RegexAtom.from_pattern_string(pattern_string, name="some pattern")
+
+        assert atom.is_in(SUCCESS_STRING)
+        assert not atom.is_in(FAIL_STRING)
+
+    def test_from_pattern_string_with_flag(self, pattern_string):
+        string_parts = pattern_string.split()
+        string_parts[0] = string_parts[0].lower()
+
+        lower_string = " ".join(string_parts)
+
+        atom = RegexAtom.from_pattern_string(lower_string, re.I, re.M)
+
+        assert atom.is_in(SUCCESS_STRING)
+        assert not atom.is_in(FAIL_STRING)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,104 @@
+import re
+from unittest import mock
+
+import pytest
+
+from avwx.parsing import Parser, AtomHandler, BaseAtom, RegexAtom
+from avwx.parsing.exceptions import TranslationError
+
+
+SAMPLE_STRING = """TH1S 1S AN 3NC0D3D STRING"""
+
+
+class TestParser:
+    def test_iter_handlers_that_can_handle_string(self):
+        parser = Parser()
+
+        handler_1 = mock.MagicMock(spec=AtomHandler)
+        handler_2 = mock.MagicMock(spec=AtomHandler)
+        handler_3 = mock.MagicMock(spec=AtomHandler)
+
+        handler_1.can_handle.return_value = True
+        handler_2.can_handle.return_value = False
+        handler_3.can_handle.return_value = True
+
+        parser.register_handler(handler_1)
+        parser.register_handler(handler_2)
+        parser.register_handler(handler_3)
+
+        handlers = list(parser._iter_handlers_that_can_handle_string(SAMPLE_STRING))
+
+        assert handlers == [handler_1, handler_3]
+
+
+class TestParsingIntegration:
+    BASE_EXPECTED = {
+        "TH1S 1S": "THIS IS: 1",
+        "AN 3NC0D3D": "AN ENCODED: 303",
+        "STRING": "STRING",
+    }
+
+    def make_parser(self):
+        atom_1 = RegexAtom.from_pattern_string("TH1S 1S")
+        atom_2 = RegexAtom.from_pattern_string("AN 3NC0D3D")
+        atom_3 = RegexAtom.from_pattern_string("STRING")
+        atom_4 = RegexAtom.from_pattern_string("NOT PRESENT")
+
+        handler_1 = AtomHandler(atom_1, lambda atom, string: "THIS IS: 1")
+        handler_2 = AtomHandler(atom_2, lambda atom, string: "AN ENCODED: 303")
+        handler_3 = AtomHandler(atom_3, lambda atom, string: "STRING")
+        handler_4 = AtomHandler(atom_4, lambda atom, string: "NOPE")
+
+        parser = Parser()
+
+        for handler in [handler_4, handler_3, handler_2, handler_1]:
+            parser.register_handler(handler)
+
+        return parser
+
+    def test_parse_into_translations(self):
+        parser = self.make_parser()
+
+        translations = parser.parse_into_translations(SAMPLE_STRING)
+
+        expected = {
+            "TH1S 1S": "THIS IS: 1",
+            "AN 3NC0D3D": "AN ENCODED: 303",
+            "STRING": "STRING",
+        }
+
+        assert translations == expected
+
+    def test_strict_parse_into_translations(self):
+        parser = self.make_parser()
+
+        bad_atom = mock.MagicMock()
+        bad_atom.name = "BAD ATOM"
+        bad_handler = AtomHandler(bad_atom, lambda a, s: "should do nothing")
+        bad_handler.can_handle = mock.MagicMock(return_value=True)
+        bad_handler.translate = mock.MagicMock(side_effect=TranslationError("no"))
+
+        parser.register_handler(bad_handler)
+
+        with pytest.raises(TranslationError, match="no") as exc_info:
+            result = parser.parse_into_translations(SAMPLE_STRING, strict=True)
+
+        expected = self.BASE_EXPECTED.copy()
+        expected.update({"BAD ATOM": "ERROR: " + "no"})
+
+        result = parser.parse_into_translations(SAMPLE_STRING, strict=False)
+
+        assert expected == result
+
+    def test_register_unregister_handler(self):
+        parser = self.make_parser()
+
+        handler = mock.MagicMock(spec=AtomHandler)
+
+        parser.register_handler(handler)
+
+        assert handler in parser.handlers
+
+        parser.unregister_handler(handler)
+
+        assert not handler in parser.handlers

--- a/tests/test_translation_handlers.py
+++ b/tests/test_translation_handlers.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest import mock
+from collections import OrderedDict
+
+from avwx.parsing.atom_handlers import AtomHandler, BaseAtom
+from avwx.parsing.atom import AtomSpan
+from avwx.parsing.exceptions import CanNotHandleError
+
+SAMPLE_STRING = "THIS IS A SAMPLE STRING WITH 3NC0D3D DATA"
+
+
+def translate_sample_string(span: AtomSpan, string: str) -> str:
+    context = span.context or {}
+
+    context_od = OrderedDict(**context)
+
+    context_str = f" context: {str(list(context_od.values()))}" if context_od else ""
+
+    return f"Decoded: 303{context_str}"
+
+
+@pytest.fixture
+def mocked_atom_handler() -> AtomHandler:
+    """
+    AtomHandler with a mocked atom that can be configured before
+    handler test calls. The translation callable simply returns
+    "Decoded: 303" and should be mocked for different behaviors.
+
+    Default mocked calls:
+        * atom.name = "Sample Atom"
+    """
+    mock_atom = mock.MagicMock()
+    mock_atom.name = "Sample Atom"
+
+    handler = AtomHandler(mock_atom, translate_sample_string)
+
+    return handler
+
+
+class TestAtomHandler:
+    def test_can_handle(self, mocked_atom_handler):
+        handler = mocked_atom_handler
+        handler.atom.is_in.return_value = True
+
+        assert handler.can_handle(SAMPLE_STRING)
+
+        handler.atom.is_in.return_value = False
+
+        assert not handler.can_handle(SAMPLE_STRING)
+
+    def test_translation_handler_signature(self, mocked_atom_handler):
+        """Test that the translation is strictly called with the correct signature"""
+        handler = mocked_atom_handler
+        handler.atom.is_in.return_value = True
+
+        mock_translation = mock.MagicMock(return_value=SAMPLE_STRING)
+        handler.translation_callable = mock_translation
+
+        _ = handler.translate(SAMPLE_STRING)
+
+        mocked_atom_handler.translation_callable.assert_called_with(
+            handler.atom.to_atom_span(), SAMPLE_STRING,
+        )
+
+    def test_translate_atom(self, mocked_atom_handler):
+        handler = mocked_atom_handler
+        handler.atom.is_in.return_value = True
+
+        result = handler.translate(SAMPLE_STRING)
+
+        assert result == "Decoded: 303" == handler(SAMPLE_STRING)
+
+    def test_translate_atom_raises_for_can_not_handle(self, mocked_atom_handler):
+        handler = mocked_atom_handler
+        handler.atom.is_in.return_value = False
+
+        with pytest.raises(CanNotHandleError) as exc_info:
+            result = handler.translate(SAMPLE_STRING)
+
+        expected = f"{handler.atom!r} has nothing to translate from {SAMPLE_STRING!r}"
+
+        assert expected in str(exc_info.value)
+
+    def test_create_simple_translation(self, mocked_atom_handler):
+        match = "THIS IS A MATCH"
+        output = "OUTPUT"
+        mock_atom = mock.MagicMock(spec=BaseAtom)
+        mock_atom.to_atom_span.return_value.match = match
+
+        handler = AtomHandler.create_simple_translation(mock_atom, output, "simple")
+
+        assert handler.translate("THIS IS A MOCKED") == "OUTPUT"


### PR DESCRIPTION
Reference #23 

So, here's roughly what I was thinking... it's peppered with todo's and comments that should be beautified and documented once you decide what you like/dislike. 

**Stating the problem:** Currently, the parsing is done by scanning across input strings and pulling patterns out based on string operations. This can be unwieldy over time as more translations are added that contain things like multi-word elements and/or similar patterns that have very subtle differences that may be handled too prematurely and incorrectly. 

**Common Terms**

* Atom: a piece of text in a string that has some meaning. For now, I feel that regular expressions are the most flexible way of defining them as word boundaries can be made explicit without chopping up an input string. But the `RegexAtom` should have a class method that makes it dead simple to add a new one with a simple pattern like `RegexAtom.from_pattern(r"\bACFT MSHP\b")`. Currently only the `RegexAtom` is implemented, but I could see the use for a `CallableAtom` that uses string methods to determine its presence in a larger corpus of text. 

* AtomSpan: the main product of the Atom. It describes the matching text from the pattern, the location of the pattern, and any contextual key-value information that can be decoded and consumed in the translations.

* Translation: a callable that receives an `AtomSpan` and an input string and returns a translated string.

* AtomHandler: an object that binds the translation(possibly more than one translation in the future) to the Atom and orchestrates the translation. Each handler should have a name that indicates its intended translation purpose.. i.e. "Aircraft Mishap[ Handler?]"

* Parser: the collection of handlers that does the actual parsing. There should be a parser for each type of parsing to be done. So the `remarks` module would really only have to instantiate a parser for the module -> provide a `parse` method that uses the parser. The parser class could also have a default handler for errors.

**Application Structure**:

I believe there are benefits from moving away from the flat package structure as this parsing system grows into more of a framework. However, only the classes required to make a module level parser should be in the `__init__.py` so that the API stays clean. 

**Things to think about**:

* Should the patterns/translations that are used for a module's parser be in their own package? The benefits would be much cleaner parsing modules as only the handlers would need to be defined. Since regex patterns are ugly and translations could possibly be reused, I can see the case for keeping them in their own spaces. 

* Should the AtomSpan be a dataclass? I think immutability should be used whenever possible, but there's always the frozen=True option.

I think this may end up being Gilligan's "Three Hour Tour". I'm happy to work on it with you, but we may want to make a Project Board for this and use issues for discussions on changes/implementation/planning.

Also, this code is ugly, unfinished, and undocumented. I wrote most of this on deadheads so by all means, change it all up! Once we get settled on the next steps, it may be a good idea to start writing up some docs for it. 
