### PR TITLE
Support TAF variable wind direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# VSCode
+.vscode/
+
 /.pytest_cache/
 /.nox
 /notes.txt

--- a/avwx/current/taf.py
+++ b/avwx/current/taf.py
@@ -404,7 +404,13 @@ def parse_line(
     sanitized = " ".join(data)
     data, report_type, start_time, end_time, transition = get_type_and_times(data)
     data, wind_shear = get_wind_shear(data)
-    data, wind_direction, wind_speed, wind_gust, _ = core.get_wind(data, units)
+    (
+        data, 
+        wind_direction, 
+        wind_speed, 
+        wind_gust, 
+        wind_variable_direction
+     ) = core.get_wind(data, units)
     if "CAVOK" in data:
         visibility = core.make_number("CAVOK")
         clouds: List[Cloud] = []
@@ -433,6 +439,7 @@ def parse_line(
         turbulence=turbulence,
         type=report_type,
         wind_shear=wind_shear,
+        wind_variable_direction=wind_variable_direction,
     )
 
 

--- a/avwx/parsing/speech.py
+++ b/avwx/parsing/speech.py
@@ -180,6 +180,7 @@ def taf_line(line: TafLineData, units: Units) -> str:
                 line.wind_direction,
                 line.wind_speed,
                 line.wind_gust,
+                line.wind_variable_direction,
                 unit=units.wind_speed,
             )
         )

--- a/avwx/parsing/translate/taf.py
+++ b/avwx/parsing/translate/taf.py
@@ -108,6 +108,7 @@ def translate_taf(wxdata: TafData, units: Units) -> TafTrans:
                 line.wind_direction,
                 line.wind_speed,
                 line.wind_gust,
+                line.wind_variable_direction,
                 unit=units.wind_speed,
             ),
             wind_shear=wind_shear(line.wind_shear, units.altitude, units.wind_speed),

--- a/avwx/structs.py
+++ b/avwx/structs.py
@@ -240,6 +240,7 @@ class TafLineData(SharedData):
     turbulence: List[str]
     type: str
     wind_shear: Optional[str]
+    wind_variable_direction: Optional[List[Number]]
 
 
 @dataclass

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.14
+- Added support for `wind_variable_direction` to TAF report forcasts
+
 ## 1.8.x
 
 - Added `Notams` report class

--- a/docs/av/metar.md
+++ b/docs/av/metar.md
@@ -156,7 +156,7 @@ Returns `True` if a new report is available, else `False`
 
 **wind_speed**: *avwx.structs.Number*
 
-**wind_variable_direction**: *avwx.structs.Number*
+**wind_variable_direction**: *List[avwx.structs.Number]*
 
 ## class avwx.structs.**MetarTrans**
 

--- a/docs/av/taf.md
+++ b/docs/av/taf.md
@@ -184,6 +184,8 @@ Returns `True` if a new report is available, else `False`
 
 **wind_speed**: *avwx.structs.Number*
 
+**wind_variable_direction**: *avwx.structs.Number*
+
 ## class avwx.structs.**TafLineTrans**
 
 **altimeter**: *str*

--- a/docs/av/taf.md
+++ b/docs/av/taf.md
@@ -184,7 +184,7 @@ Returns `True` if a new report is available, else `False`
 
 **wind_speed**: *avwx.structs.Number*
 
-**wind_variable_direction**: *avwx.structs.Number*
+**wind_variable_direction**: *List[avwx.structs.Number]*
 
 ## class avwx.structs.**TafLineTrans**
 

--- a/tests/current/data/taf/EGLL.json
+++ b/tests/current/data/taf/EGLL.json
@@ -45,6 +45,7 @@
                     "spoken": "one nine zero",
                     "value": 190
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -92,6 +93,7 @@
                     "value": 7000
                 },
                 "wind_direction": null,
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": null,

--- a/tests/current/data/taf/KJFK.json
+++ b/tests/current/data/taf/KJFK.json
@@ -52,6 +52,7 @@
                     "spoken": "one nine zero",
                     "value": 190
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -106,6 +107,7 @@
                     "spoken": "one nine zero",
                     "value": 190
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -160,6 +162,7 @@
                     "spoken": "one eight zero",
                     "value": 180
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -207,6 +210,7 @@
                     "spoken": "one eight zero",
                     "value": 180
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -254,6 +258,7 @@
                     "spoken": "two zero zero",
                     "value": 200
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {

--- a/tests/current/data/taf/KMCO.json
+++ b/tests/current/data/taf/KMCO.json
@@ -59,6 +59,7 @@
                     "spoken": "one two zero",
                     "value": 120
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -113,6 +114,7 @@
                     "spoken": "one three zero",
                     "value": 130
                 },
+                "wind_variable_direction": [],
                 "wind_gust": {
                     "repr": "15",
                     "spoken": "one five",
@@ -171,6 +173,7 @@
                     "spoken": "one one zero",
                     "value": 110
                 },
+                "wind_variable_direction": [],
                 "wind_gust": {
                     "repr": "18",
                     "spoken": "one eight",
@@ -229,6 +232,7 @@
                     "spoken": "one two zero",
                     "value": 120
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {

--- a/tests/current/data/taf/PHNL.json
+++ b/tests/current/data/taf/PHNL.json
@@ -59,6 +59,7 @@
                     "spoken": "zero six zero",
                     "value": 60
                 },
+                "wind_variable_direction": [],
                 "wind_gust": {
                     "repr": "22",
                     "spoken": "two two",
@@ -117,6 +118,7 @@
                     "spoken": "zero six zero",
                     "value": 60
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -164,6 +166,7 @@
                     "spoken": "zero six zero",
                     "value": 60
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -211,6 +214,7 @@
                     "spoken": "zero six zero",
                     "value": 60
                 },
+                "wind_variable_direction": [],
                 "wind_gust": null,
                 "wind_shear": null,
                 "wind_speed": {
@@ -265,6 +269,7 @@
                     "spoken": "zero six zero",
                     "value": 60
                 },
+                "wind_variable_direction": [],
                 "wind_gust": {
                     "repr": "22",
                     "spoken": "two two",

--- a/tests/current/test_taf.py
+++ b/tests/current/test_taf.py
@@ -46,6 +46,7 @@ TAF_FIELDS = (
     "transition_start",
     "start_time",
     "end_time",
+    "wind_variable_direction",
 )
 
 
@@ -349,6 +350,16 @@ def test_wind_shear():
     assert lines[0].wind_shear == "WS015/20055"
     assert tafobj.translations.forecast[1].clouds == ""
 
+def test_wind_variable_direction():
+    """Variable wind direction should be recognized when present"""
+    report = (
+        "MNPC 301530Z 3018/3118 16006KT 100V200 5000 RA/TSRA FEW014CB BKN016TCU "
+        "BECMG 3100/3102 VRB04KT 6000 -RA/HZ BKN016"
+    )
+    tafobj = taf.Taf.from_report(report)
+    lines = tafobj.data.forecast
+    assert len(lines) == 2
+    assert len(lines[0].wind_variable_direction) == 2
 
 def test_prob_tempo():
     """Non-PROB types should take precident but still fill the probability value"""

--- a/tests/parsing/test_speech.py
+++ b/tests/parsing/test_speech.py
@@ -232,12 +232,12 @@ def test_taf_line():  # sourcery skip: dict-assign-update-to-union
         "wind_shear": "WS020/07040KT",
         "wind_speed": core.make_number("12"),
         "wx_codes": get_wx_codes(["+RA"])[1],
-        "wind_variable_direction": [core.make_number("40"), core.make_number("120")],
+        "wind_variable_direction": [core.make_number("320"), core.make_number("370")],
     }
     line.update({k: None for k in empty_fields})
     line = structs.TafLineData(**line)
     spoken = (
-        "From 2 to 6 zulu, Winds three six zero at 12 knots gusting to 20 knots. "
+        "From 2 to 6 zulu, Winds three six zero (variable three two zero to three seven zero) at 12 knots gusting to 20 knots. "
         "Wind shear 2000ft from zero seven zero at 40 knots. Visibility three miles. "
         "Altimeter two nine point nine two. Heavy Rain. "
         "Broken layer at 1500ft (Cumulonimbus). "

--- a/tests/parsing/test_speech.py
+++ b/tests/parsing/test_speech.py
@@ -232,6 +232,7 @@ def test_taf_line():  # sourcery skip: dict-assign-update-to-union
         "wind_shear": "WS020/07040KT",
         "wind_speed": core.make_number("12"),
         "wx_codes": get_wx_codes(["+RA"])[1],
+        "wind_variable_direction": [core.make_number("40"), core.make_number("120")],
     }
     line.update({k: None for k in empty_fields})
     line = structs.TafLineData(**line)

--- a/tests/parsing/test_translate.py
+++ b/tests/parsing/test_translate.py
@@ -277,6 +277,7 @@ def test_taf():
         "type",
         "flight_rules",
         "sanitized",
+        "wind_variable_direction",
     )
     empty_fields = (
         "raw",


### PR DESCRIPTION
## Description

I've added support for variable wind direction as it is possible for a TAF string to contain this information as seen below:
`MNPC 301530Z 3018/3118 16006KT 100V200 5000 RA/TSRA FEW014CB BKN016TCU BECMG 3100/3102 VRB04KT 6000 -RA/HZ BKN016`

## Checklist

- [X] Tests covering the new functionality have been added
- [X] Documentation has been updated OR the change is too minor to be documented
- [X] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
