### PR TITLE
Add support for TAF forecast times that use a space rather than a forward slash

### DIFF
--- a/avwx/current/taf.py
+++ b/avwx/current/taf.py
@@ -135,7 +135,7 @@ def get_type_and_times(
             and data[0][5:].isdigit()
         ):
             start_time, end_time = data.pop(0).split("/")
-        
+
         # 1200 1306
         elif (
             len(data) == 8

--- a/avwx/current/taf.py
+++ b/avwx/current/taf.py
@@ -135,6 +135,18 @@ def get_type_and_times(
             and data[0][5:].isdigit()
         ):
             start_time, end_time = data.pop(0).split("/")
+        
+        # 1200 1306
+        elif (
+            len(data) == 8
+            and len(data[0]) == 4
+            and len(data[1]) == 4
+            and data[0].isdigit()
+            and data[1].isdigit()
+        ):
+            start_time = data.pop(0)
+            end_time = data.pop(0)
+
         # 120000
         elif len(data[0]) == 6 and data[0].isdigit() and data[0][-2:] == "00":
             start_time = data.pop(0)[:4]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.15
+- Added support for TAF forecast times that use a space rather than a forward slash
+
 ## 1.8.14
 - Added support for `wind_variable_direction` to TAF report forcasts
 

--- a/tests/current/test_taf.py
+++ b/tests/current/test_taf.py
@@ -351,6 +351,23 @@ def test_wind_shear():
     assert tafobj.translations.forecast[1].clouds == ""
 
 
+def test_space_in_forcast_times():
+    """Forecast time can occasionally use a space rather than a slash"""
+    report = (
+        "TAF VIGR 041530Z 0500/0512 04005KT 6000 SCT025 BKN090 "
+        "0501 0503 05010KT 4000 -RA/BR SCT015 SCT025 BKN090 " 
+        "TEMPO 0507 0511 05010G20KT 2000 RASH/TS SCT025 FEWCB035 SCT090"
+    )
+    tafobj = taf.Taf("VIGR")
+    tafobj.parse(report)
+    lines = tafobj.data.forecast
+    assert len(lines) == 2
+    assert lines[0].start_time == core.make_timestamp("0500")
+    assert lines[0].end_time == core.make_timestamp("0512")
+    assert lines[1].start_time == core.make_timestamp("0507")
+    assert lines[1].end_time == core.make_timestamp("0511")
+
+
 def test_wind_variable_direction():
     """Variable wind direction should be recognized when present"""
     report = (

--- a/tests/current/test_taf.py
+++ b/tests/current/test_taf.py
@@ -355,7 +355,7 @@ def test_space_in_forcast_times():
     """Forecast time can occasionally use a space rather than a slash"""
     report = (
         "TAF VIGR 041530Z 0500/0512 04005KT 6000 SCT025 BKN090 "
-        "0501 0503 05010KT 4000 -RA/BR SCT015 SCT025 BKN090 " 
+        "0501 0503 05010KT 4000 -RA/BR SCT015 SCT025 BKN090 "
         "TEMPO 0507 0511 05010G20KT 2000 RASH/TS SCT025 FEWCB035 SCT090"
     )
     tafobj = taf.Taf("VIGR")


### PR DESCRIPTION
## Description

Occasionally, TAF strings arrive with a space rather than a slash in the time period token. Currently these are not supported in AVWX and will result in a forecast line that does not have valid `start_time` and `end_time` values. A small change allows this kind of format to be supported.

## Checklist

- [X] Tests covering the new functionality have been added
- [X] Documentation has been updated OR the change is too minor to be documented
- [X] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
