### PR TITLE
Add handling for special visibility string `M1SM` as `less than one`

### DIFF
--- a/avwx/parsing/core.py
+++ b/avwx/parsing/core.py
@@ -395,7 +395,7 @@ def get_visibility(data: List[str], units: Units) -> Tuple[List[str], Optional[N
         item = copy(data[0])
         # Vis reported in statue miles
         if item.endswith("SM"):  # 10SM
-            if item in ("P6SM", "M1/2SM", "M1/4SM", "M1/8SM"):
+            if item in ("P6SM", "M1SM", "M1/2SM", "M1/4SM", "M1/8SM"):
                 visibility = item[:-2]
             elif item[:-2].isdigit():
                 visibility = str(int(item[:-2]))

--- a/avwx/static/core.py
+++ b/avwx/static/core.py
@@ -186,6 +186,7 @@ FRACTIONS = {"1/4": "one quarter", "1/2": "one half", "3/4": "three quarters"}
 #: Dictionary associating special number values with their spoken version
 SPECIAL_NUMBERS = {
     "CAVOK": (9999, "ceiling and visibility ok"),
+    "M1": (None, "less than one"),
     "M1/2": (None, "less than one half"),
     "M1/2SM": (None, "less than one half"),
     "M1/4": (None, "less than one quarter"),

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
-## 1.8.16
+## 1.8.17
 
 - Added handling for special visibility string `M1SM` as `less than one`
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,16 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.16
+
+- Added handling for special visibility string `M1SM` as `less than one`
+
 ## 1.8.15
+
 - Added support for TAF forecast times that use a space rather than a forward slash
 
 ## 1.8.14
+
 - Added support for `wind_variable_direction` to TAF report forcasts
 
 ## 1.8.x

--- a/tests/parsing/test_core.py
+++ b/tests/parsing/test_core.py
@@ -269,6 +269,7 @@ def test_get_wind(wx: List[str], unit: str, wind: Tuple[tuple], varv: List[tuple
         (["05SM", "1"], "sm", ("5", 5)),
         (["10SM", "1"], "sm", ("10", 10)),
         (["P6SM", "1"], "sm", ("P6",)),
+        (["M1SM", "1"], "sm", ("M1",)),
         (["M1/2SM", "1"], "sm", ("M1/2",)),
         (["M1/4SM", "1"], "sm", ("M1/4",)),
         (["1/2SM", "1"], "sm", ("1/2", 0.5)),


### PR DESCRIPTION
## Add handling for special visibility string `M1SM` as `less than one`

Spotted in a METAR string, `M1SM` should be parsed as "visibility less than one statute mile".

A search shows references to this string. For example, this page uses `M1SM` example of "M" as a prefix standing for "less than":
https://wiki.ivao.aero/en/home/training/documentation/METAR_explanation

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
