### PR TITLE
Generic parsing of `M` as "less than" and `P` as "greater than"

### DIFF
--- a/avwx/static/core.py
+++ b/avwx/static/core.py
@@ -186,16 +186,6 @@ FRACTIONS = {"1/4": "one quarter", "1/2": "one half", "3/4": "three quarters"}
 #: Dictionary associating special number values with their spoken version
 SPECIAL_NUMBERS = {
     "CAVOK": (9999, "ceiling and visibility ok"),
-    "M1/2": (None, "less than one half"),
-    "M1/2SM": (None, "less than one half"),
-    "M1/4": (None, "less than one quarter"),
-    "M1/4SM": (None, "less than one quarter"),
-    "M1/8": (None, "less than one eighth"),
-    "M1/8SM": (None, "less than one eighth"),
-    "P49": (None, "greater than four nine"),
-    "P6": (None, "greater than six"),
-    "P6SM": (None, "greater than six"),
-    "P99": (None, "greater than nine nine"),
     "VRB": (None, "variable"),
     "CLM": (0, "calm"),
     "SFC": (0, "surface"),

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,16 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.17
+
+- Add optional `m_minus` parameter to `make_number()` for prefixes 'M' as "less than" and 'P' as "greater than"
+
 ## 1.8.15
+
 - Added support for TAF forecast times that use a space rather than a forward slash
 
 ## 1.8.14
+
 - Added support for `wind_variable_direction` to TAF report forcasts
 
 ## 1.8.x

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,11 @@ Parsing and sanitization improvements are always ongoing and non-breaking
 
 ## 1.8.17
 
-- Add optional `m_minus` parameter to `make_number()` for prefixes 'M' as "less than" and 'P' as "greater than"
+- Added optional `m_minus` parameter (bool, defaults to `True`) to `make_number()`, as well as logic changes, to allow for generic parsing of prefixes 'M' as "less than" and 'P' as "greater than" without breaking existing 'M' as "-" logic.
+- Added optional `speak_prefix` parameter (str, defaults to "")  to `make_fraction()` to allow `make_number()` to determine "greater than" or "less than" prefix on a fractional value.
+- Removes static mappings for strings that utilize "P"/"M" prefixes.
+- Updates `get_wind()` and `get_visibility()` to set `m_minus=False` in calls to `make_number()`.
+- Updates unit tests to reflect changes.
 
 ## 1.8.15
 

--- a/tests/parsing/test_core.py
+++ b/tests/parsing/test_core.py
@@ -125,8 +125,6 @@ def test_spoken_number(num: str, spoken: str):
         ("300", 300, "three hundred"),
         ("25000", 25000, "two five thousand"),
         ("M10", -10, "minus one zero"),
-        ("P6SM", None, "greater than six"),
-        ("M1/4", None, "less than one quarter"),
         ("FL310", 310, "flight level three one zero"),
         ("ABV FL480", 480, "above flight level four eight zero"),
     ),
@@ -134,6 +132,22 @@ def test_spoken_number(num: str, spoken: str):
 def test_make_number(num: str, value: Union[int, float, None], spoken: str):
     """Tests Number dataclass generation from a number string"""
     number = core.make_number(num)
+    assert isinstance(number, Number)
+    assert number.repr == num
+    assert number.value == value
+    assert number.spoken == spoken
+
+
+@pytest.mark.parametrize(
+    "num,value,spoken",
+    (
+        ("P6SM", None, "greater than six"),
+        ("M1/4", None, "less than one quarter"),
+    ),
+)
+def test_make_number_gt_lt(num: str, value: Union[int, float, None], spoken: str):
+    """Tests Number dataclass generation when using P/M for greater/less than"""
+    number = core.make_number(num, m_minus=False)
     assert isinstance(number, Number)
     assert number.repr == num
     assert number.value == value
@@ -385,7 +399,7 @@ def test_get_flight_rules(vis: Optional[str], ceiling: Optional[tuple], rule: st
 
     Note: Only 'Broken', 'Overcast', and 'Vertical Visibility' are considered ceilings
     """
-    vis = core.make_number(vis)
+    vis = core.make_number(vis, m_minus=False)
     if ceiling:
         ceiling = structs.Cloud(None, *ceiling)
     assert static.core.FLIGHT_RULES[core.get_flight_rules(vis, ceiling)] == rule

--- a/tests/parsing/test_speech.py
+++ b/tests/parsing/test_speech.py
@@ -74,7 +74,10 @@ def test_temperature(temp: str, unit: str, spoken: str):
 )
 def test_visibility(vis: str, unit: str, spoken: str):
     """Tests converting visibility distance into a spoken string"""
-    assert speech.visibility(core.make_number(vis), unit) == f"Visibility {spoken}"
+    assert (
+        speech.visibility(core.make_number(vis, m_minus=False), unit)
+        == f"Visibility {spoken}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -271,7 +274,7 @@ def test_taf():
                 "probability": core.make_number("45"),
                 "start_time": core.make_timestamp("0412Z"),
                 "end_time": core.make_timestamp("0414Z"),
-                "visibility": core.make_number("M1/4"),
+                "visibility": core.make_number("M1/4", m_minus=False),
             },
         )
     ]

--- a/tests/parsing/test_translate.py
+++ b/tests/parsing/test_translate.py
@@ -32,7 +32,10 @@ from avwx.parsing import core, remarks, translate
 )
 def test_visibility(vis: str, unit: str, translation: str):
     """Tests visibility translation and conversion"""
-    assert translate.base.visibility(core.make_number(vis), unit) == translation
+    assert (
+        translate.base.visibility(core.make_number(vis, m_minus=False), unit)
+        == translation
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

- Adds optional `m_minus` parameter (bool, defaults to `True`) to `make_number()`, as well as logic changes, to allow for generic parsing of prefixes 'M' as "less than" and 'P' as "greater than" without breaking existing 'M' as "-" logic.
- Adds optional `speak_prefix` parameter (str, defaults to "")  to `make_fraction()` to allow `make_number()` to determine "greater than" or "less than" prefix on a fractional value.
- Removes static mappings for strings that utilize these prefixes.
- Updates `get_wind()` and `get_visibility()` to set `m_minus=False` in calls to  `make_number()`.
- Splits `test_make_number()` parameters  that require `m_minus=False` into a separate test.
- Sets `m_minus=False` in a few other unit tests that call `make_number()` for visibility/cloud strings.

Very open to feedback on this implementation, but existing unit tests are all passing with only very minor updates.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
