### PR TITLE
Handle bad TAF headers

### DIFF
--- a/avwx/current/taf.py
+++ b/avwx/current/taf.py
@@ -296,6 +296,41 @@ def get_taf_flight_rules(lines: List[TafLineData]) -> List[TafLineData]:
     return lines
 
 
+def fix_report_header(report_str):
+    # Split the report string into individual components
+    split_report = report_str.split()
+
+    # Extract TAF, AMD, and COR components if present
+    taf = ""
+    amd = ""
+    cor = ""
+    non_header_tokens = []
+
+    if "TAF" in split_report:
+        taf_index = split_report.index("TAF")
+        taf = " ".join(split_report[taf_index : taf_index + 1])
+
+    if "AMD" in split_report:
+        amd_index = split_report.index("AMD")
+        amd = " ".join(split_report[amd_index : amd_index + 1])
+
+    if "COR" in split_report:
+        cor_index = split_report.index("COR")
+        cor = " ".join(split_report[cor_index : cor_index + 1])
+
+    # Extract the rest of the components
+    non_header_tokens = [
+        token for token in split_report if token not in ["TAF", "AMD", "COR"]
+    ]
+
+    # Reassemble the fixed report string
+    fixed_report_str = (
+        " ".join([taf, amd, cor] + non_header_tokens).replace("  ", " ").strip()
+    )
+
+    return fixed_report_str
+
+
 def parse(
     station: str, report: str, issued: Optional[date] = None
 ) -> Tuple[Optional[TafData], Optional[Units], Optional[Sanitization]]:
@@ -304,6 +339,7 @@ def parse(
     if not report:
         return None, None, None
     valid_station(station)
+    report = fix_report_header(report)
     while len(report) > 3 and report[:4] in ("TAF ", "AMD ", "COR "):
         report = report[4:]
     start_time: Optional[Timestamp] = None

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.18
+
+ - Added function `fix_report_header()`. Provides additional santization of report string to handle cases where the ICAO code is out of order.
+ - Updated unit tests to reflect changes.
+
+## 1.8.17
+
+- Added optional `m_minus` parameter (bool, defaults to `True`) to `make_number()`, as well as logic changes, to allow for generic parsing of prefixes 'M' as "less than" and 'P' as "greater than" without breaking existing 'M' as "-" logic.
+- Added optional `speak_prefix` parameter (str, defaults to "")  to `make_fraction()` to allow `make_number()` to determine "greater than" or "less than" prefix on a fractional value.
+- Removes static mappings for strings that utilize "P"/"M" prefixes.
+- Updates `get_wind()` and `get_visibility()` to set `m_minus=False` in calls to `make_number()`.
+- Updates unit tests to reflect changes.
+
 ## 1.8.15
 - Added support for TAF forecast times that use a space rather than a forward slash
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Parsing and sanitization improvements are always ongoing and non-breaking
 
 ## 1.8.18
 
- - Added function `fix_report_header()`. Provides additional santization of report string to handle cases where the ICAO code is out of order.
+ - Added function `fix_report_header()`. Provides additional sanitization of report string to handle cases where the ICAO code is out of order.
  - Updated unit tests to reflect changes.
 
 ## 1.8.17

--- a/tests/current/test_taf.py
+++ b/tests/current/test_taf.py
@@ -343,7 +343,7 @@ def test_bad_header():
     tafobj = taf.Taf.from_report(report)
     lines = tafobj.data.forecast
     assert len(lines) == 7
-    assert tafobj.data.station == "KGNU"
+    assert tafobj.data.station == "KNGU"
 
 
 def test_wind_shear():

--- a/tests/current/test_taf.py
+++ b/tests/current/test_taf.py
@@ -332,6 +332,20 @@ def test_prob_end():
     assert lines[-1].end_time.repr == "2602"
 
 
+def test_bad_header():
+    report = (
+        "KNGU TAF COR 2315/2415 18011KT 9999 VCTS FEW020CB BKN050 BKN150 QNH2986INS "
+        "TEMPO 2315/2319 VRB30G60KT 0400 +TSRAGR FG BKN020CB OVC050 "
+        "TEMPO 2319/2401 VRB30G60KT 0400 +TSRAGR FG BKN020CB OVC050 FM240200 19008KT 9999 BKN030 OVC100 QNH2986INS "
+        "FM240800 20005KT 9999 BKN010 OVC030 QNH2985INS TEMPO 2408/2414 6000 BR BKN006 OVC015 "
+        "FM241400 22008KT 9999 SCT015 BKN150 QNH2980INS TX30/2319Z TN23/2410Z COR 1520 FN20004"
+    )
+    tafobj = taf.Taf.from_report(report)
+    lines = tafobj.data.forecast
+    assert len(lines) == 7
+    assert tafobj.data.station == "KGNU"
+
+
 def test_wind_shear():
     """Wind shear should be recognized as its own element in addition to wind"""
     report = (


### PR DESCRIPTION
## Description

 - Added function `fix_report_header()`. Provides additional sanitization of report string to handle cases where the ICAO code is out of order.
 - Updated unit tests to reflect changes.

Occasionally, TAF reports come with the headers out of order. See below for an example:

> KNGU TAF COR 2315/2415 18011KT 9999 VCTS FEW020CB BKN050 BKN150 QNH2986INS TEMPO 2315/2319 VRB30G60KT 0400 +TSRAGR FG BKN020CB OVC050 TEMPO 2319/2401 VRB30G60KT 0400 +TSRAGR FG BKN020CB OVC050 FM240200 19008KT 9999 BKN030 OVC100 QNH2986INS FM240800 20005KT 9999 BKN010 OVC030 QNH2985INS TEMPO 2408/2414 6000 BR BKN006 OVC015 FM241400 22008KT 9999 SCT015 BKN150 QNH2980INS TX30/2319Z TN23/2410Z COR 1520 FN20004

## Checklist

- [X] Tests covering the new functionality have been added
- [X] Documentation has been updated OR the change is too minor to be documented
- [X] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
