### PR TITLE
Parse untranslated `wx_codes` into `other`

### DIFF
--- a/avwx/current/base.py
+++ b/avwx/current/base.py
@@ -34,6 +34,9 @@ def wx_code(code: str) -> Union[Code, str]:
     # Return code if code is not a code, ex R03/03002V03
     if len(code) not in [2, 4, 6] or code.isdigit():
         return code
+    # Return code if no translatable codes are present
+    if not any(wx_tok in code for wx_tok in WX_TRANSLATIONS.keys()):
+        return code
     while code:
         try:
             ret += f"{WX_TRANSLATIONS[code[:2]]} "

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,14 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.19
+
+- Updated `wx_code()` to parse tokens without translations end up in `other` rather than `wx_codes`.
+
 ## 1.8.18
 
- - Added function `fix_report_header()`. Provides additional sanitization of report string to handle cases where the ICAO code is out of order.
- - Updated unit tests to reflect changes.
+- Added function `fix_report_header()`. Provides additional sanitization of report string to handle cases where the ICAO code is out of order.
+- Updated unit tests to reflect changes.
 
 ## 1.8.17
 

--- a/tests/current/test_current.py
+++ b/tests/current/test_current.py
@@ -26,6 +26,9 @@ def test_wxcode(code: str, value: str):
     assert current.base.wx_code(code) == obj
 
 
-@pytest.mark.parametrize("code,value", (("", ""), ("R03/03002V03", "R03/03002V03")))
+@pytest.mark.parametrize(
+    "code,value",
+    (("", ""), ("R03/03002V03", "R03/03002V03"), ("CB", "CB"), ("0800SE", "0800SE")),
+)
 def test_unknown_code(code: str, value: str):
     assert current.base.wx_code(code) == value


### PR DESCRIPTION
## Description

Updates `avwx.current.base.wx_code()` to return the `code` unmodified if it contains no strings that are in `avwx.static.core.WX_TRANSLATIONS`.

This causes directional visibility and some other random tokens to end up in `other` rather than `wx_codes`.

Some example tokens from METAR reports that previously were parsed into `wx_codes` and are now parsed into `other` with this change:
- Directional visibility token `0800SE` from report `EGJB 011850Z 20012KT 1200 0800SE -RADZ BCFG BR SCT000 BKN001 16/16 Q1003 RERA REDZ`
- Cloud Movement? token `CB(SE-N)` from report `GBYD 291500Z 25006KT 9000 -RA BKN011 FEW018CB SCT110 26/25 Q101 1 CB(SE-N)`


## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
