### PR TITLE
Update docs to link to avwx types

### DIFF
--- a/docs/av/airsigmet.md
+++ b/docs/av/airsigmet.md
@@ -45,7 +45,7 @@ Async updates list of reports by fetching from all sources
 
 Returns `True` if new reports are available, else `False`
 
-#### **contains**(*coord: [avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)*) -> *List[avwx.AigSigmet]*
+#### **contains**(*coord: [avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)*) -> *List[[avwx.AigSigmet](#class-avwxaigsigmet)]*
 
 Returns available reports that contain a coordinate
 
@@ -141,13 +141,13 @@ Units inferred from the report contents
 
 **correction**: *Optional[str]*
 
-**end_time**: *Optional[avwx.structs.Timestamp]*
+**end_time**: *Optional[[avwx.structs.Timestamp](../util/structs.md#class-avwxstructstimestamp)]*
 
-**forecast**: *Optional[avwx.structs.AirSigObservation]*
+**forecast**: *Optional[[avwx.structs.AirSigObservation](#class-avwxstructsairsigmetobservation)]*
 
 **issuer**: *str*
 
-**observation**: *Optional[avwx.structs.AirSigObservation]*
+**observation**: *Optional[[avwx.structs.AirSigObservation](#class-avwxstructsairsigmetobservation)]*
 
 **raw**: *str*
 
@@ -157,11 +157,11 @@ Units inferred from the report contents
 
 **sanitized**: *str*
 
-**start_time**: *Optional[avwx.structs.Timestamp]*
+**start_time**: *Optional[[avwx.structs.Timestamp](../util/structs.md#class-avwxstructstimestamp)]*
 
 **station**: *Optional[str]*
 
-**time**: *Optional[avwx.structs.Timestamp]*
+**time**: *Optional[[avwx.structs.Timestamp](../util/structs.md#class-avwxstructstimestamp)]*
 
 **type**: *str*
 
@@ -169,24 +169,24 @@ Units inferred from the report contents
 
 **bounds**: *List[str]*
 
-**ceiling**: *Optional[avwx.structs.Number]*
+**ceiling**: *Optional[[avwx.structs.Number](../util/structs.md#class-avwxstructsnumber)]*
 
-**coords**: *List[avwx.structs.Coord]*
+**coords**: *List[[avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)]*
 
-**end_time**: *Optional[avwx.structs.Timestamp]*
+**end_time**: *Optional[[avwx.structs.Timestamp](../util/structs.md#class-avwxstructstimestamp)]*
 
-**floor**: *Optional[avwx.structs.Number]*
+**floor**: *Optional[[avwx.structs.Number](../util/structs.md#class-avwxstructsnumber)]*
 
-**intensity**: *Optional[avwx.structs.Code]*
+**intensity**: *Optional[[avwx.structs.Code](../util/structs.md#class-avwxstructscode)]*
 
-**movement**: *Optional[avwx.structs.Movement]*
+**movement**: *Optional[[avwx.structs.Movement](../util/structs.md#class-avwxstructsmovement)]*
 
 **other**: *List[str]*
 
 **poly**: *Optional[shapely.geometry.Polygon]*
 
-**position**: *Optional[avwx.structs.Coord]*
+**position**: *Optional[[avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)]*
 
-**start_time**: *Optional[avwx.structs.Timestamp]*
+**start_time**: *Optional[[avwx.structs.Timestamp](../util/structs.md#class-avwxstructstimestamp)]*
 
-**type**: *Optional[avwx.structs.Code]*
+**type**: *Optional[[avwx.structs.Code](../util/structs.md#class-avwxstructscode)]*

--- a/docs/av/airsigmet.md
+++ b/docs/av/airsigmet.md
@@ -35,7 +35,7 @@ Code(repr='WA', value='airmet')
 'AIRMET SIERRA FOR IFR AND MTN OBSCN'
 ```
 
-#### **along**(*coords: List[avwx.structs.Coord]*) -> *List[avwx.AigSigmet]*
+#### **along**(*coords: List[[avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)]* -> *List[[avwx.AigSigmet](#class-avwxaigsigmet)]*
 
 Returns available reports the intersect a flight path
 
@@ -45,7 +45,7 @@ Async updates list of reports by fetching from all sources
 
 Returns `True` if new reports are available, else `False`
 
-#### **contains**(*coord: avwx.structs.Coord*) -> *List[avwx.AigSigmet]*
+#### **contains**(*coord: [avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)*) -> *List[avwx.AigSigmet]*
 
 Returns available reports that contain a coordinate
 
@@ -57,7 +57,7 @@ UTC Datetime object when the reports were last updated
 
 List of the original fetched report strings
 
-#### **reports**: *List[avwx.AirSigmet]* = *None*
+#### **reports**: *List[[avwx.AigSigmet](#class-avwxaigsigmet)]* = *None*
 
 List of parsed `avwx.AirSigmet` objects
 
@@ -89,7 +89,7 @@ Code(repr='NC', value='No change')
 Number(repr='FL410', value=410, spoken='flight level four one zero')
 ```
 
-#### **contains**(*coord: avwx.structs.Coord*) -> *bool*
+#### **contains**(*coord: [avwx.structs.Coord](../util/structs.md#class-avwxstructscoord)*) -> *bool*
 
 Returns True if the report area contains a coordinate
 
@@ -127,7 +127,7 @@ The unparsed report string
 
 Source URL root used to pull the current report data
 
-#### **units**: *[avwx.structs.Units](../util/structs#class-avwxstructsunits)*
+#### **units**: *[avwx.structs.Units](../util/structs.md#class-avwxstructsunits)*
 
 Units inferred from the report contents
 
@@ -137,7 +137,7 @@ Units inferred from the report contents
 
 **body**: *str*
 
-**bulletin**: *[avwx.structs.Bulletin](../util/structs#class-avwxstructsbulletin)*
+**bulletin**: *[avwx.structs.Bulletin](../util/structs.md#class-avwxstructsbulletin)*
 
 **correction**: *Optional[str]*
 

--- a/docs/av/airsigmet.md
+++ b/docs/av/airsigmet.md
@@ -93,11 +93,11 @@ Number(repr='FL410', value=410, spoken='flight level four one zero')
 
 Returns True if the report area contains a coordinate
 
-#### **data**: *avwx.structs.AirSigmetData* = *None*
+#### **data**: *[avwx.structs.AirSigmetData](#class-avwxstructsairsigmetdata)* = *None*
 
 AirSigmetData dataclass of parsed data values and units
 
-#### **from_report**(*report: str*) -> *avwx.AigSigmet*
+#### **from_report**(*report: str*) -> *[avwx.AigSigmet](#class-avwxaigsigmet)*
 
 Returns an updated report object based on an existing report
 
@@ -127,7 +127,7 @@ The unparsed report string
 
 Source URL root used to pull the current report data
 
-#### **units**: *avwx.structs.Units*
+#### **units**: *[avwx.structs.Units](../util/structs#class-avwxstructsunits)*
 
 Units inferred from the report contents
 
@@ -137,7 +137,7 @@ Units inferred from the report contents
 
 **body**: *str*
 
-**bulletin**: *avwx.structs.Bulletin*
+**bulletin**: *[avwx.structs.Bulletin](../util/structs#class-avwxstructsbulletin)*
 
 **correction**: *Optional[str]*
 


### PR DESCRIPTION
## Description

The docs show the avwx-specific types that are used as arguments or return values, but only as text. It would be easier to navigate the docs if the types were updated to be links instead. I've updated the `airsigmet.md` file to show what I have in mind, and have confirmed that the links work as expected when run through `mkdocs`. @flyinactor91 , what are your thoughts on a change like this? I'm happy to update the other md files and issue a full PR if this is a change you'd be open to.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
