### PR TITLE
Fix README docs instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ The documentation is automatically generated from the content of the [docs direc
  You can also preview local changes during development:
 
 ```sh
-cd docs
 mkdocs serve
 ```
 


### PR DESCRIPTION
## Description

The README said that you need to be in the "docs" directory to run `mkdocs serve`. If you do that, though, you get this error: "Error: Config file 'mkdocs.yml' does not exist."

The "mkdocs.yml" file is actually located at the root of the repo, which is where the mkdocs command should be run from as well.

## Checklist

- [ ] ~Tests covering the new functionality have been added~
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
