### PR TITLE
Preserve Station ID when sanitizing Wind Speed

### DIFF
--- a/avwx/parsing/sanitization/base.py
+++ b/avwx/parsing/sanitization/base.py
@@ -83,6 +83,9 @@ def sanitize_list_with(
 
         # Check for wind sanitization
         for i, item in enumerate(wxdata):
+            # Skip Station
+            if i == 0:
+                continue
             if is_variable_wind_direction(item):
                 replaced = item[:7]
                 wxdata[i] = replaced

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Parsing and sanitization improvements are always ongoing and non-breaking
 ## 1.8.20
 
 - Updated wind sanitization to ensure Station ID is protected.
+- Updated unit test to validate fix.
 
 ## 1.8.19
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 Parsing and sanitization improvements are always ongoing and non-breaking
 
+## 1.8.20
+
+- Updated wind sanitization to ensure Station ID is protected.
+
 ## 1.8.19
 
 - Updated `wx_code()` to parse tokens without translations end up in `other` rather than `wx_codes`.

--- a/tests/parsing/data/sanitize_metar_list_cases.json
+++ b/tests/parsing/data/sanitize_metar_list_cases.json
@@ -126,8 +126,8 @@
         "extra_spaces_needed": false
     },
     {
-        "report": "KTRK 241545Z RMK A02",
-        "fixed": "KTRK 241545Z RMK AO2",
+        "report": "K13K 241545Z RMK A02",
+        "fixed": "K13K 241545Z RMK AO2",
         "removed": [],
         "replaced": {"A02": "AO2"},
         "duplicates": false,


### PR DESCRIPTION
## Description

A minor modification to skip the Station ID token during the Wind Speed sanitation that is performed within `parsing.sanitation.base.py::sanitize_report_list()`. Prior to this change, some station IDs that end in "K" were being erroneously corrected to end in "KT". 

I modified an existing test case within `tests/parsing/data/sanitize_metar_list_cases.json` to validate. Prior to this change, `K13K` would become `K13KT` after sanitation.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
