### PR TITLE
Fix bulk fetch services after aviationweather.gov v3.0 update

### DIFF
--- a/avwx/service/base.py
+++ b/avwx/service/base.py
@@ -72,7 +72,10 @@ class CallsHTTP:
     ) -> str:
         name = self.__class__.__name__
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=True,
+            ) as client:
                 for _ in range(retries):
                     if self.method.lower() == "post":
                         resp = await client.post(

--- a/avwx/service/bulk.py
+++ b/avwx/service/bulk.py
@@ -25,7 +25,7 @@ class NOAA_Bulk(Service, CallsHTTP):
     `"airsigmet"` as valid report types.
     """
 
-    _url = "https://aviationweather.gov/adds/dataserver_current/current/{}s.cache.csv"
+    _url = "https://aviationweather.gov/data/cache/{}s.cache.csv"
     _valid_types = ("metar", "taf", "aircraftreport", "airsigmet")
     _rtype_map = {"airep": "aircraftreport", "pirep": "aircraftreport"}
     _targets = {"aircraftreport": -2}  # else 0
@@ -68,21 +68,18 @@ class NOAA_Intl(Service, CallsHTTP):
     Currently, this class only accepts `"airsigmet"` as a valid report type.
     """
 
-    _url = "https://www.aviationweather.gov/{}/intl"
+    _url = "https://www.aviationweather.gov/api/data/{}"
     _valid_types = ("airsigmet",)
-    _url_map = {"airsigmet": "sigmet"}
+    _url_map = {"airsigmet": "isigmet"}
 
     @staticmethod
     def _clean_report(report: str) -> str:
-        # for remove in (r"\x07",):
-        #     report = report.replace(remove, " ")
-        return " ".join(report.split())
+        lines = report.split()
+        return " ".join([line for line in lines if not line.startswith("Hazard:")])
 
     def _extract(self, raw: str) -> List[str]:
         reports = []
-        raw = raw[raw.find("<pre>") + 5 :]
-        raw = raw[: raw.find("</pre>")]
-        for line in raw.split("<br/>"):
+        for line in raw.split("----------------------"):
             reports.append(self._clean_report(line.strip().strip('"')))
         return reports
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Parsing and sanitization improvements are always ongoing and non-breaking
 
 - Updated wind sanitization to ensure Station ID is protected.
 - Updated unit test to validate fix.
+- Update `NOAA_Bulk` and `NOAA_Intl` to work with the AviationWeather.gov v3.0 update.
 
 ## 1.8.19
 


### PR DESCRIPTION
## Description

[AviationWeather.gov released v3.0 today, which changed a bunch of their URLs.](https://aviationweather.gov/help/changelog/)

This PR fixes both the `NOAA_Bulk` and `NOAA_Intl` services. 

The path used for the `stations.txt` data used in `avwx.stations.build_stations()` no longer exists there, but I was unable to find a new path containing the same format. There's https://aviationweather.gov/api/data/stationinfo but that is a completely different format.

I'm sure the Scrape services also need updating as well, but have not looked myself yet.

## Checklist

- [x] Tests covering the new functionality have been added (none added, updating existing behavior only)
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
