### PR TITLE
Fixed the issue where parts of the report were missing.

### DIFF
--- a/avwx/service/scrape.py
+++ b/avwx/service/scrape.py
@@ -90,7 +90,7 @@ class StationScrape(ScrapeService):
                 raise self._make_err(msg)
             raw = raw[index:]
         report = raw[: raw.find(end)].strip()
-        return " ".join(dedupe(report.split()))
+        return " ".join(report.split())
 
     async def _fetch(self, station: str, url: str, params: dict, timeout: int) -> str:
         headers = self._make_headers()


### PR DESCRIPTION
## Description

Incorrect use of the `dedupe()` function caused some content to be lost from the message retrieved from the webpage.
For example,
`091100Z 0912/1018 12005KT 3500 BR RA SCT025 FEW030CB BKN080 BECMG 0915/0917 14005KT 3000 **BR** -RA **SCT025** BKN090 TEMPO 1000/1004 11008KT 1500 TSRA FEW015 **SCT025 FEW030CB** OVC090 **BECMG** 1005/1007 11010G20KT 2500 **BR -RA SCT025 BKN090 BECMG** 1015/1017 **14005KT 3000 BR -RA** FEW030 SCT090`
After the `dedupe()`, the message comes to,
`091100Z 0912/1018 12005KT 3500 BR RA SCT025 FEW030CB BKN080 BECMG 0915/0917 14005KT 3000 -RA BKN090 TEMPO 1000/1004 11008KT 1500 TSRA FEW015 OVC090 1005/1007 11010G20KT 2500 1015/1017 FEW030 SCT090`
many parts are lost.

This PR fixed this issue.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
