### PR TITLE
Use .splitlines() instead of .split() for NoaaIntl

### DIFF
--- a/avwx/service/bulk.py
+++ b/avwx/service/bulk.py
@@ -71,7 +71,7 @@ class NoaaIntl(Service, CallsHTTP):
 
     @staticmethod
     def _clean_report(report: str) -> str:
-        lines = report.split()
+        lines = report.splitlines()
         return " ".join([line for line in lines if not line.startswith("Hazard:")])
 
     def _extract(self, raw: str) -> list[str]:


### PR DESCRIPTION
When using the [`AirSigManager`](https://engine.avwx.rest/avwx.html#AirSigManager), I got the following error:
```
  File "c:\env\Lib\site-packages\avwx\current\airsigmet.py", line 247, in _bulletin
    type=Code(repr=type_key, value=BULLETIN_TYPES[type_key]),
                                   ~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'VA'
```
After further investigation, I found out that the cause lies in the processing of the Data API message from aviationweather.gov for [international SIGMETs](https://aviationweather.gov/data/api/#/Data/dataiSIGMET).

These include the type of hazard in the first line, which is also taken into account in `NoaaIntl`. However, this first line is filtered out incorrectly.

This can be fixed by using `.splitlines()` instead of `.split()`, as it is probably also intended.
