### PR TITLE
fix: now skips the report header words in find_station to prevent IATA collision

### DIFF
--- a/avwx/base.py
+++ b/avwx/base.py
@@ -23,9 +23,15 @@ except ImportError:
     from typing_extensions import Self
 
 
+# Report header words that are never station codes
+_REPORT_HEADERS = {"METAR", "SPECI", "TAF", "COR", "AMD", "RTD"}
+
+
 def find_station(report: str) -> Station | None:
     """Returns the first Station found in a report string"""
     for item in report.split():
+        if item.upper() in _REPORT_HEADERS:
+            continue
         with suppress(BadStation):
             return Station.from_code(item.upper())
     return None


### PR DESCRIPTION
Fixes #75 

TAF reports start with the word "TAF" which is also a valid IATA 
code for Oran Tafraoui Airport (DAOL). find_station() was returning 
DAOL instead of the actual station.

Fix: added a set of known report header words (TAF, METAR, SPECI, 
COR, AMD, RTD) that get skipped before checking for a station code.

Tested with the example from the issue- now correctly returns LHBP.