### PR TITLE
Fix/sigmet slow movement parsing

### DIFF
--- a/avwx/base.py
+++ b/avwx/base.py
@@ -23,9 +23,15 @@ except ImportError:
     from typing_extensions import Self
 
 
+# Report header words that are never station codes
+_REPORT_HEADERS = {"METAR", "SPECI", "TAF", "COR", "AMD", "RTD"}
+
+
 def find_station(report: str) -> Station | None:
     """Returns the first Station found in a report string"""
     for item in report.split():
+        if item.upper() in _REPORT_HEADERS:
+            continue
         with suppress(BadStation):
             return Station.from_code(item.upper())
     return None

--- a/avwx/current/airsigmet.py
+++ b/avwx/current/airsigmet.py
@@ -370,6 +370,14 @@ def _movement(data: list[str], units: Units) -> tuple[list[str], Units, Movement
     # MOV CNL
     if direction_str == "CNL":
         return data, units, None
+    # MOV SLOW ESE / MOV SLOW "SLOW" is a speed qualifier, not a direction
+    if direction_str == "SLOW":
+        raw += f" {direction_str}"
+        if index < len(data):
+            direction_str = data.pop(index)
+            raw += f" {direction_str}"
+        direction = core.make_number(direction_str.replace("/", ""), literal=True, special=CARDINAL_DEGREES)
+        return data, units, Movement(repr=raw.strip(), direction=direction, speed=None)
     raw += f" {direction_str} "
     # MOV FROM 23040KT
     if direction_str == "FROM":


### PR DESCRIPTION
Fixes #69 
SIGMET reports can contain MOV SLOW ESE where SLOW is an ICAO speed qualifier meaning the weather system is moving slowly. The _movement() function was passing SLOW directly into make_number() as a direction string, causing a ValueError: invalid literal for int() with base 10: 'SLOW'.
Fix detects SLOW before direction parsing and grabs the next token (ESE) as the actual direction instead.
Tested with the exact report from the issue and now correctly returns:
Movement(repr='MOV SLOW ESE', direction=ESE 112.5°, speed=None)
