### PR TITLE
fix(service): accept SPECI and amended TAF headers when scraping

### DIFF
--- a/avwx/service/scrape.py
+++ b/avwx/service/scrape.py
@@ -57,6 +57,20 @@ class ScrapeService(Service, CallsHTTP):
         """Return request headers."""
         return {}
 
+    def _report_variants(self) -> list[str]:
+        """Return the report headers a source may use for this report type.
+
+        A METAR request can be answered with an off-schedule SPECI, and a TAF
+        request with an amended or corrected forecast. Sources label those with
+        the variant header rather than the requested type.
+        """
+        report_type = self.report_type.upper()
+        if report_type == "METAR":
+            return [report_type, "SPECI"]
+        if report_type == "TAF":
+            return [report_type, "TAF AMD", "TAF COR"]
+        return [report_type]
+
     def _post_data(self, station: str) -> dict:  # noqa: ARG002
         """Return the POST form/data payload."""
         return {}
@@ -332,7 +346,7 @@ class Olbs(StationScrape):
         if index == -1:
             raise self._make_err(raw)
         report = raw[index + len(target) :]
-        if not report.startswith(f"{prefix} "):
+        if not any(report.startswith(f"{variant} ") for variant in self._report_variants()):
             msg = "The station might not exist"
             raise self._make_err(msg)
         return report[: report.find("=")]
@@ -349,7 +363,10 @@ class Nam(StationScrape):
 
     def _extract(self, raw: str, station: str) -> str:
         """Extract the reports from HTML response."""
-        starts = [f">{self.report_type.upper()} <", f">{station.upper()}<", "top'>"]
+        headers = [f">{variant} <" for variant in self._report_variants()]
+        # Fall back to the requested type so a miss reports the same error as before
+        header = next((h for h in headers if h in raw), headers[0])
+        starts = [header, f">{station.upper()}<", "top'>"]
         report = self._simple_extract(raw, starts, "=")
         index = report.rfind(">")
         if index > -1:

--- a/tests/service/test_scrape.py
+++ b/tests/service/test_scrape.py
@@ -157,6 +157,64 @@ class TestNamClass(TestStationScrape):
     service_class = service.Nam
 
 
+class TestReportVariants:
+    """Report headers that sources substitute for the requested type."""
+
+    @pytest.mark.parametrize(
+        ("report_type", "expected"),
+        [
+            ("metar", ["METAR", "SPECI"]),
+            ("taf", ["TAF", "TAF AMD", "TAF COR"]),
+        ],
+    )
+    def test_variants(self, report_type: str, expected: list[str]) -> None:
+        serv = service.Nam(report_type)
+        assert serv._report_variants() == expected
+
+
+class TestNamVariantExtract:
+    """Nam should extract reports issued under a variant header."""
+
+    @staticmethod
+    def _html(header: str, station: str, body: str) -> str:
+        return f"<td>>{header} <b>{station}</b> top'>{station} {body}=</td>"
+
+    @pytest.mark.parametrize("header", ["METAR", "SPECI"])
+    def test_metar_headers(self, header: str) -> None:
+        serv = service.Nam("metar")
+        body = "301050Z 18008KT 9999 FEW035 12/06 Q1013"
+        report = serv._extract(self._html(header, "ENGM", body), "ENGM")
+        assert report.endswith(body)
+
+    @pytest.mark.parametrize("header", ["TAF", "TAF AMD", "TAF COR"])
+    def test_taf_headers(self, header: str) -> None:
+        serv = service.Nam("taf")
+        body = "301100Z 3011/3111 18010KT 9999"
+        report = serv._extract(self._html(header, "ENGM", body), "ENGM")
+        assert report.endswith(body)
+
+    def test_missing_report_still_raises(self) -> None:
+        serv = service.Nam("metar")
+        with pytest.raises(exceptions.InvalidRequest):
+            serv._extract("<html>nothing here</html>", "ENGM")
+
+
+class TestOlbsVariantExtract:
+    """Olbs should accept a SPECI in response to a METAR request."""
+
+    @pytest.mark.parametrize("header", ["METAR", "SPECI"])
+    def test_metar_headers(self, header: str) -> None:
+        serv = service.Olbs("metar")
+        body = "VIDP 301050Z 09006KT 3000 HZ SCT025 32/24 Q1002"
+        report = serv._extract(f"<b>METAR:</b><br>{header} {body}=", "VIDP")
+        assert report == f"{header} {body}"
+
+    def test_unknown_header_still_raises(self) -> None:
+        serv = service.Olbs("metar")
+        with pytest.raises(exceptions.InvalidRequest):
+            serv._extract("<b>METAR:</b><br>XXXXX VIDP 301050Z=", "VIDP")
+
+
 # @pytest.mark.parametrize("station", ["ZJQH", "ZYCC", "ZSWZ"])
 # class TestAvt(ServiceFetchTest):
 #     service_class = service.Avt


### PR DESCRIPTION
Fixes #74

## The problem

`Nam` and `Olbs` match the report header against `self.report_type`, so a station that has issued an off-schedule **SPECI**, or an **amended/corrected TAF**, fails extraction — and surfaces as `The station might not exist` even though valid data is present in the response.

Reproduced against current `main`:

```
=== Nam METAR service ===
  METAR    -> OK   'ENGM ENGM 301050Z 18008KT 9999 FEW035 12/06 Q1013'
  SPECI    -> FAIL InvalidRequest: ... The station might not exist

=== Nam TAF service ===
  TAF      -> OK   'ENGM ENGM 301100Z 3011/3111 18010KT 9999'
  TAF AMD  -> FAIL InvalidRequest: ... The station might not exist

=== Olbs METAR service ===
  METAR    -> OK   'METAR VIDP 301050Z 09006KT 3000 HZ SCT025 32/24 Q1002'
  SPECI    -> FAIL InvalidRequest: ... The station might not exist
```

`Nam` builds its tag as `>METAR <` / `>TAF <`. A response headed `>SPECI <` or `>TAF AMD <` never matches, since the longer headers don't contain the shorter tag. `Olbs` asserts the body starts with `"METAR "` and rejects a SPECI outright.

The misleading error is the part most likely to cost someone time — it points at the station rather than the header.

## The change

Adds `ScrapeService._report_variants()` returning the headers a source may substitute for the requested type, and uses it in both services.

This follows a precedent already in the codebase — `Amo` accepts SPECI alongside the requested type when trimming its prefix:

```python
for item in (self.report_type.upper(), "SPECI"):
    if report.startswith(f"{item} "):
```

so the concern is already recognised here, just not applied consistently. I put the helper on `ScrapeService` rather than duplicating the logic, in case other services need it later.

## Behaviour preserved

- Unchanged when the requested type is what comes back
- A genuinely absent report still raises the same error — `Nam` falls back to the requested type, so an unmatched response fails exactly as before (covered by a test)

## Verification

| | baseline | with change |
|---|---|---|
| `tests/service/test_scrape.py` | 100 passed | **111 passed** |
| full suite | 29 failed, 1091 passed | 29 failed, **1102** passed |

The 29 failures are identical with and without the change — all `MissingExtraModule` from an optional extra I don't have installed locally, unrelated to this.

`ruff check` reports the same 12 pre-existing findings on these two files before and after, so this adds none. I deliberately did **not** run `ruff format` on them, since it wants to reformat unrelated regions and would bury the diff — happy to if you'd prefer.

New tests cover METAR/SPECI for both services, TAF/TAF AMD/TAF COR for `Nam`, and that a missing report still raises `InvalidRequest`.

I couldn't exercise this against the live NorthAviMet or OLBS endpoints, so the tests drive `_extract` with response-shaped fixtures. If the real markup differs from what I assumed, that's the part worth a close look.

---

Disclosure: found and drafted with AI assistance (Claude Code). Every result above comes from running the code, not from inspection.